### PR TITLE
Fix potential out-of-bounds

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -235,5 +235,8 @@ func nextIP(prev net.IP) net.IP {
 // firmwares, leaving to packet drops.
 func ipConfusesBuggyFirmwares(ip net.IP) bool {
 	ip = ip.To4()
-	return ip[len(ip)-1] == 0 || ip[len(ip)-1] == 255
+	if ip == nil {
+		return false
+	}
+	return ip[net.IPv4len-1] == 0 || ip[net.IPv4len-1] == 255
 }


### PR DESCRIPTION
ipConfusesBuggyFirmwares could potentially do a `len(a)-1` when a would
be nil, leading to -1 --> out of bounds.