### PR TITLE
Add arp-speaker

### DIFF
--- a/arp-speaker/main.go
+++ b/arp-speaker/main.go
@@ -1,0 +1,227 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+
+	"go.universe.tf/metallb/internal/allocator"
+	"go.universe.tf/metallb/internal/arp"
+	"go.universe.tf/metallb/internal/config"
+	"go.universe.tf/metallb/internal/k8s"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/api/core/v1"
+)
+
+type controller struct {
+	myIP   net.IP
+	myNode string
+
+	config *config.Config
+	ips    *allocator.Allocator
+	ann    *arp.Announce
+
+	// Metrics
+	announcing *prometheus.GaugeVec
+}
+
+func (c *controller) SetBalancer(name string, svc *v1.Service, eps *v1.Endpoints) error {
+	if svc == nil {
+		return c.deleteBalancer(name, "service deleted")
+	}
+
+	if svc.Spec.Type != "LoadBalancer" {
+		return nil
+	}
+
+	glog.Infof("%s: start update", name)
+	defer glog.Infof("%s: end update", name)
+
+	if c.config == nil {
+		glog.Infof("%s: skipped, waiting for config", name)
+		return nil
+	}
+
+	if len(svc.Status.LoadBalancer.Ingress) != 1 {
+		glog.Infof("%s: no IP allocated by controller", name)
+		return c.deleteBalancer(name, "no IP allocated by controller")
+	}
+
+	// Should we advertise? Yes, if externalTrafficPolicy is Cluster,
+	// or Local && there's a ready local endpoint.
+	if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal && !c.nodeHasHealthyEndpoint(eps) {
+		glog.Infof("%s: externalTrafficPolicy is Local, and no healthy local endpoints", name)
+		return c.deleteBalancer(name, "no healthy local endpoints")
+	}
+
+	lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP).To4()
+	if lbIP == nil {
+		glog.Errorf("%s: invalid LoadBalancer IP %q", name, svc.Status.LoadBalancer.Ingress[0].IP)
+		return c.deleteBalancer(name, "invalid IP allocated by controller")
+	}
+
+	if err := c.ips.Assign(name, lbIP); err != nil {
+		glog.Errorf("%s: IP %q assigned by controller is not allowed by config", name, lbIP)
+		return c.deleteBalancer(name, "invalid IP allocated by controller")
+	}
+
+	poolName := c.ips.GetPool(name)
+	pool := c.config.Pools[c.ips.GetPool(name)]
+	if pool == nil {
+		glog.Errorf("%s: could not find pool %q that definitely should exist!", name, poolName)
+		return c.deleteBalancer(name, "can't find pool")
+	}
+
+	glog.Infof("%s: announcable, making advertisement", name)
+
+	c.ann.SetBalancer(name, lbIP)
+
+	c.announcing.With(prometheus.Labels{
+		"service": name,
+		"node":    c.myNode,
+		"ip":      lbIP.String(),
+	}).Set(1)
+
+	return nil
+}
+
+func (c *controller) nodeHasHealthyEndpoint(eps *v1.Endpoints) bool {
+	ready := map[string]bool{}
+	for _, subset := range eps.Subsets {
+		for _, ep := range subset.Addresses {
+			if ep.NodeName == nil || *ep.NodeName != c.myNode {
+				continue
+			}
+			if _, ok := ready[ep.IP]; !ok {
+				// Only set true if nothing else has expressed an
+				// opinion. This means that false will take precedence
+				// if there's any unready ports for a given endpoint.
+				ready[ep.IP] = true
+			}
+		}
+		for _, ep := range subset.NotReadyAddresses {
+			ready[ep.IP] = false
+		}
+	}
+
+	for _, r := range ready {
+		if r {
+			// At least one fully healthy endpoint on this machine.
+			return true
+		}
+	}
+	return false
+}
+
+func (c *controller) deleteBalancer(name, reason string) error {
+	glog.Infof("%s: stopping announcements, %s", name, reason)
+	c.announcing.Delete(prometheus.Labels{
+		"service": name,
+		"node":    c.myNode,
+		"ip":      c.ips.GetIP(name).String(),
+	})
+	c.ips.Unassign(name)
+	c.ann.DeleteBalancer(name)
+	return nil
+}
+
+func (c *controller) SetConfig(cfg *config.Config) error {
+	glog.Infof("Start config update")
+	defer glog.Infof("End config update")
+
+	if cfg == nil {
+		glog.Errorf("No MetalLB configuration in cluster")
+		return errors.New("configuration missing")
+	}
+
+	if err := c.ips.SetPools(cfg.Pools); err != nil {
+		glog.Errorf("Applying new configuration failed: %s", err)
+		return fmt.Errorf("configuration rejected: %s", err)
+	}
+
+	return nil
+}
+
+func (c *controller) MarkSynced() {}
+
+func newController(myIP net.IP, myNode string) (*controller, error) {
+	ann, err := arp.New(myIP)
+	if err != nil {
+		return nil, err
+	}
+	c := &controller{
+		myIP:   myIP,
+		myNode: myNode,
+		ips:    allocator.New(),
+
+		announcing: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "metallb",
+			Subsystem: "speaker",
+			Name:      "announced",
+			Help:      "Services being announced from this node. This is desired state, it does not guarantee that the routing protocols have converged.",
+		}, []string{
+			"service",
+			"node",
+			"ip",
+		}),
+	}
+	// get arp.ann and start that as well, figure out interface from IP address.
+	prometheus.MustRegister(c.announcing)
+	ann.Start()
+	return c, nil
+}
+
+func main() {
+	kubeconfig := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	master := flag.String("master", "", "master url")
+	myIPstr := flag.String("node-ip", "", "IP address of this Kubernetes node")
+	myNode := flag.String("node-name", "", "name of this Kubernetes node")
+	port := flag.Int("port", 80, "HTTP listening port")
+	flag.Parse()
+
+	if *myIPstr == "" {
+		*myIPstr = os.Getenv("METALLB_NODE_IP")
+	}
+	if *myNode == "" {
+		*myNode = os.Getenv("METALLB_NODE_NAME")
+	}
+
+	myIP := net.ParseIP(*myIPstr).To4()
+	if myIP == nil {
+		glog.Fatalf("Invalid --node-ip %q, must be an IPv4 address", *myIPstr)
+	}
+
+	if *myNode == "" {
+		glog.Fatalf("Must specify --node-name")
+	}
+
+	c, err := newController(myIP, *myNode)
+	if err != nil {
+		glog.Fatalf("Error getting controller: %s", err)
+	}
+
+	client, err := k8s.NewClient("metallb-arp-speaker", *master, *kubeconfig, c, true)
+	if err != nil {
+		glog.Fatalf("Error getting k8s client: %s", err)
+	}
+	glog.Fatal(client.Run(*port))
+}

--- a/internal/arp/arp.go
+++ b/internal/arp/arp.go
@@ -1,0 +1,153 @@
+package arp
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/mdlayher/arp"
+	"github.com/mdlayher/ethernet"
+)
+
+// Announce is used to "announce" new IPs mapped to the node's MAC address.
+type Announce struct {
+	hardwareAddr net.HardwareAddr
+	client       *arp.Client
+	c            chan *arp.Packet
+	ips          map[string]net.IP // map containing IPs we should announce
+	sync.RWMutex                   // protects ips
+}
+
+// New return an initialized Announce.
+func New(ip net.IP) (*Announce, error) {
+	ifi, err := interfaceByIP(ip)
+	if err != nil {
+		return nil, err
+	}
+	client, err := arp.Dial(ifi)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Announce{
+		hardwareAddr: ifi.HardwareAddr,
+		client:       client,
+		c:            make(chan *arp.Packet),
+		ips:          make(map[string]net.IP),
+	}, nil
+}
+
+// Start starts the announcer, making it listen on the interface for ARP requests.
+func (a *Announce) Start() {
+	// Read packet from the wire.
+	go func() {
+		for {
+			pkt, eth, err := a.client.Read()
+
+			// Ignore ARP replies.
+			if pkt.Operation != arp.OperationRequest {
+				continue
+			}
+
+			// Ignore ARP requests which are not broadcast or bound directly for this machine.
+			if !bytes.Equal(eth.Destination, ethernet.Broadcast) && !bytes.Equal(eth.Destination, a.hardwareAddr) {
+				continue
+			}
+
+			// Ignore ARP requests which do not indicate the target IP that we should announce.
+			if !a.Announce(pkt.TargetIP) {
+				continue
+			}
+
+			if err != nil {
+				continue
+			}
+
+			a.c <- pkt
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case pkt := <-a.c:
+				// pkt.TargetIP has been vetted to be "the one".
+				glog.Infof("request: who-has %s?  tell %s (%s). reply: %s is-at %s", pkt.TargetIP, pkt.SenderIP, pkt.SenderHardwareAddr, pkt.TargetIP, a.hardwareAddr)
+
+				if err := a.Reply(pkt, pkt.TargetIP); err != nil {
+					glog.Warningf("Failed to writes ARP response for %s: %s", pkt.TargetIP, err)
+				}
+			}
+		}
+	}()
+}
+
+// Reply sends a arp reply using the client in a.
+func (a *Announce) Reply(pkt *arp.Packet, ip net.IP) error {
+	return a.client.Reply(pkt, a.hardwareAddr, ip)
+}
+
+// Close closes the arp client in a.
+func (a *Announce) Close() error {
+	return a.client.Close()
+}
+
+// SetBalancer implementes.. bla bla bla
+// Now only uses an net.IP.
+func (a *Announce) SetBalancer(name string, ip net.IP) {
+	a.Lock()
+	defer a.Unlock()
+	a.ips[name] = ip
+}
+
+// DeleteBalancer deletes...
+func (a *Announce) DeleteBalancer(name string) {
+	a.Lock()
+	defer a.Unlock()
+	if _, ok := a.ips[name]; ok {
+		delete(a.ips, name)
+	}
+}
+
+// Announce checks if ip should be announced.
+func (a *Announce) Announce(ip net.IP) bool {
+	a.RLock()
+	defer a.RUnlock()
+	for _, i := range a.ips {
+		if i.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// interfaceByIP returns the interface that has ip.
+func interfaceByIP(ip net.IP) (*net.Interface, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				if ip.Equal(v.IP) {
+					return &i, nil
+				}
+			case *net.IPAddr:
+				if ip.Equal(v.IP) {
+					return &i, nil
+				}
+			}
+		}
+	}
+
+	return nil, errors.New("not found")
+}


### PR DESCRIPTION
This adds a arp-speaker that will make an LB IP exist on the LAN by
responding to ARP request for that IP. It needs to run on a single node
and will use that node's MAC address as the destination for the service
IP.

No config changes are needed, arp-speaker will consume bgp-speaker
config and only use what it needs.

This PR only *adds* arp-speaker, it has not been hooked up to be
actually used by metallb.

Also: not tested \0/ and there is no periodic routine sending out unsolicated ARP responses.