### PR TITLE
Cleanup: arp-speaker

### DIFF
--- a/arp-speaker/leadership.go
+++ b/arp-speaker/leadership.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"time"
+
+	"go.universe.tf/metallb/internal/arp"
+
+	"github.com/golang/glog"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	le "k8s.io/client-go/tools/leaderelection"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// NewLeaderElector returns a new LeaderElector used for endpoint leader election.
+func NewLeaderElector(a *arp.Announce, ns string, client corev1.CoreV1Interface) (*le.LeaderElector, error) {
+	lock, err := rl.New(rl.EndpointsResourceLock, ns, identity, client, rl.ResourceLockConfig{Identity: identity, EventRecorder: nil})
+	if err != nil {
+		return nil, err
+	}
+
+	lec := le.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: 10 * time.Second,
+		RenewDeadline: 5 * time.Second,
+		RetryPeriod:   1 * time.Second,
+		Callbacks: le.LeaderCallbacks{
+			OnStartedLeading: func(stop <-chan struct{}) {
+				glog.Infof("Acquiring leadership")
+				a.Acquire()
+			},
+			OnStoppedLeading: func() {
+				glog.Infof("Lost leadership")
+				a.SetLeader(false)
+			},
+		},
+	}
+
+	return le.NewLeaderElector(lec)
+}
+
+const identity = "metallb-arp-speaker"

--- a/arp-speaker/main.go
+++ b/arp-speaker/main.go
@@ -186,7 +186,7 @@ func newController(myIP net.IP, myNode string) (*controller, error) {
 
 	prometheus.MustRegister(c.announcing)
 	// just start this as a goroutine, the life time is bound to this process, so there is no way to stop it.
-	go func() { ann.Start() }()
+	go func() { ann.Run() }()
 	return c, nil
 }
 

--- a/internal/arp/arp.go
+++ b/internal/arp/arp.go
@@ -119,7 +119,16 @@ func (a *Announce) Announce(ip net.IP) bool {
 
 // Unsolicited returns a slice of ARP responses that can be send out as unsolicited ARPs.
 func (a *Announce) Unsolicited() []*arp.Packet {
-	return nil
+	a.RLock()
+	defer a.RUnlock()
+
+	arps := []*arp.Packet{}
+	for _, ip := range a.ips {
+		if a, err := arp.NewPacket(arp.OperationReply, a.hardwareAddr, ip, ethernet.Broadcast, ip); err == nil {
+			arps = append(arps, a)
+		}
+	}
+	return arps
 }
 
 // interfaceByIP returns the interface that has ip.

--- a/internal/arp/arp.go
+++ b/internal/arp/arp.go
@@ -40,9 +40,9 @@ func New(ip net.IP) (*Announce, error) {
 	}, nil
 }
 
-// Start starts the announcer, making it listen on the interface for ARP requests. It only responds to these
+// Run starts the announcer, making it listen on the interface for ARP requests. It only responds to these
 // requests when a.leader is set to true, i.e. we are the current cluster wide leader for sending ARPs.
-func (a *Announce) Start() {
+func (a *Announce) Run() {
 	for {
 		pkt, eth, err := a.client.Read()
 

--- a/internal/arp/leader.go
+++ b/internal/arp/leader.go
@@ -31,7 +31,6 @@ func (a *Announce) Acquire() {
 
 		for _, u := range a.Unsolicited() {
 			a.client.WriteTo(u, ethernet.Broadcast)
-			// glog errors?
 		}
 
 		time.Sleep(500 * time.Millisecond)

--- a/internal/arp/leader.go
+++ b/internal/arp/leader.go
@@ -1,0 +1,39 @@
+package arp
+
+import (
+	"time"
+
+	"github.com/mdlayher/ethernet"
+)
+
+// Leader returns true if we are the leader in the daemonSet.
+func (a *Announce) Leader() bool {
+	a.leaderMu.RLock()
+	defer a.leaderMu.RUnlock()
+	return a.leader
+}
+
+// SetLeader sets the leader boolean to b.
+func (a *Announce) SetLeader(b bool) {
+	a.leaderMu.Lock()
+	defer a.leaderMu.Unlock()
+	a.leader = b
+}
+
+// Acquire sets the leader bit to true and sends out a unsolicited ARP replies for all VIPs that should
+// be announced. It does this repeatedly - every 0.5s - for a duration of 5 seconds.
+func (a *Announce) Acquire() {
+	start := time.Now()
+
+	a.SetLeader(true)
+
+	for time.Since(start) < 5*time.Second {
+
+		for _, u := range a.Unsolicited() {
+			a.client.WriteTo(u, ethernet.Broadcast)
+			// glog errors?
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -214,6 +214,9 @@ func (c *Client) Errorf(svc *v1.Service, kind, msg string, args ...interface{}) 
 	c.events.Eventf(svc, v1.EventTypeWarning, kind, msg, args...)
 }
 
+// ClientCoreV1 returns the embeded k8s client from Client.
+func (c *Client) ClientCoreV1() v1core.CoreV1Interface { return c.client.CoreV1() }
+
 func (c *Client) sync(key interface{}) error {
 	defer c.queue.Done(key)
 


### PR DESCRIPTION
Make arp-speaker simpler, implement leaderelection and provide the
framework for sending unsolicitated ARPs on acquiring leadership
~~(actually sending not implemented yet).~~

I needed access to the k8s client, hence the internal/k8s/kus.go change,
the rest is all local to the arp stuff.

All not tested; but this should give me a base to allow some local
testing.