### PR TITLE
Move leadership code into internal/k8s

### DIFF
--- a/arp-speaker/main.go
+++ b/arp-speaker/main.go
@@ -191,12 +191,12 @@ func main() {
 		glog.Fatalf("Error getting controller: %s", err)
 	}
 
-	client, err := k8s.NewClient("metallb-arp-speaker", *master, *kubeconfig, c, true)
+	client, err := k8s.NewClient(identity, *master, *kubeconfig, c, true)
 	if err != nil {
 		glog.Fatalf("Error getting k8s client: %s", err)
 	}
 
-	le, err := NewLeaderElector(c.ann, "metallb-system", client.ClientCoreV1()) // TODO(miek): hardcoded ns here.
+	le, err := client.NewLeaderElector(c.ann, identity)
 	if err != nil {
 		glog.Fatalf("Error setting up leader election: %s", err)
 	}
@@ -204,3 +204,5 @@ func main() {
 
 	glog.Fatal(client.Run(*port))
 }
+
+const identity = "metallb-arp-speaker"

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -215,9 +215,6 @@ func (c *Client) Errorf(svc *v1.Service, kind, msg string, args ...interface{}) 
 	c.events.Eventf(svc, v1.EventTypeWarning, kind, msg, args...)
 }
 
-// ClientCoreV1 returns the embeded k8s client from Client.
-func (c *Client) ClientCoreV1() v1core.CoreV1Interface { return c.client.CoreV1() }
-
 // NodeHasHealthyEndpoint return true if this node has at least one healthy endpoint.
 func NodeHasHealthyEndpoint(eps *v1.Endpoints, node string) bool {
 	ready := map[string]bool{}

--- a/internal/k8s/leader.go
+++ b/internal/k8s/leader.go
@@ -1,4 +1,4 @@
-package main
+package k8s
 
 import (
 	"time"
@@ -6,14 +6,13 @@ import (
 	"go.universe.tf/metallb/internal/arp"
 
 	"github.com/golang/glog"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	le "k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
-// NewLeaderElector returns a new LeaderElector used for endpoint leader election.
-func NewLeaderElector(a *arp.Announce, ns string, client corev1.CoreV1Interface) (*le.LeaderElector, error) {
-	lock, err := rl.New(rl.EndpointsResourceLock, ns, identity, client, rl.ResourceLockConfig{Identity: identity, EventRecorder: nil})
+// NewLeaderElector returns a new LeaderElector used for endpoint leader election using c.
+func (c *Client) NewLeaderElector(a *arp.Announce, identity string) (*le.LeaderElector, error) {
+	lock, err := rl.New(rl.EndpointsResourceLock, "metallb-system", identity, c.client.CoreV1(), rl.ResourceLockConfig{Identity: identity, EventRecorder: nil})
 	if err != nil {
 		return nil, err
 	}
@@ -37,5 +36,3 @@ func NewLeaderElector(a *arp.Announce, ns string, client corev1.CoreV1Interface)
 
 	return le.NewLeaderElector(lec)
 }
-
-const identity = "metallb-arp-speaker"


### PR DESCRIPTION
This moves the code into k8s.

**What this PR does / why we need it**:
*cleanup*

Fixes no issue, but discussued offline.