### PR TITLE
Add disable auto assign flag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 David Anderson <dave@natulte.net>
 Miek Gieben <miek@miek.nl>
 Xavier Naveira <xnaveira@gmail.com>
+Marcus Söderberg <msoderb@gmail.com>

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -116,6 +116,7 @@ func TestControllerMutation(t *testing.T) {
 	cfg := &config.Config{
 		Pools: map[string]*config.Pool{
 			"pool1": &config.Pool{
+				AutoAssign: true,
 				CIDR: []*net.IPNet{ipnet("1.2.3.0/31")},
 			},
 		},
@@ -393,6 +394,7 @@ func TestControllerConfig(t *testing.T) {
 	cfg := &config.Config{
 		Pools: map[string]*config.Pool{
 			"default": &config.Pool{
+				AutoAssign: true,
 				CIDR: []*net.IPNet{ipnet("1.2.3.0/24")},
 			},
 		},

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -175,9 +175,12 @@ func (a *Allocator) AllocateFromPool(service, pool string) (net.IP, error) {
 	return ip, nil
 }
 
-// Allocate assigns any available IP to service.
+// Allocate assigns any available and assignable IP to service.
 func (a *Allocator) Allocate(service string) (net.IP, error) {
 	for pname := range a.pools {
+		if !a.pools[pname].AutoAssign {
+			continue
+		}
 		if ip := a.allocateFromPool(service, pname); ip != nil {
 			return ip, nil
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,7 +83,8 @@ type Pool struct {
 	// unusable, for maximum compatibility with ancient parts of the
 	// internet.
 	AvoidBuggyIPs bool
-	// Prevents IP addresses to be automatically assigned from this pool.
+	// If false, prevents IP addresses to be automatically assigned
+	// from this pool.
 	AutoAssign bool
 	// When an IP is allocated from this pool, how should it be
 	// translated into BGP announcements?

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type configFile struct {
 		Name           string
 		CIDR           []string
 		AvoidBuggyIPs  bool `yaml:"avoid-buggy-ips"`
+		AutoAssign     *bool `yaml:"auto-assign"`
 		Advertisements []struct {
 			AggregationLength *int `yaml:"aggregation-length"`
 			LocalPref         *uint32
@@ -82,6 +83,8 @@ type Pool struct {
 	// unusable, for maximum compatibility with ancient parts of the
 	// internet.
 	AvoidBuggyIPs bool
+	// Prevents IP addresses to be automatically assigned from this pool.
+	AutoAssign bool
 	// When an IP is allocated from this pool, how should it be
 	// translated into BGP announcements?
 	Advertisements []*Advertisement
@@ -170,8 +173,14 @@ func Parse(bs []byte) (*Config, error) {
 		if _, ok := cfg.Pools[p.Name]; ok {
 			return nil, fmt.Errorf("duplicate pool definition for %q", p.Name)
 		}
+
+		autoAssign := true
+		if p.AutoAssign != nil {
+			autoAssign = *p.AutoAssign
+		}
 		pool := &Pool{
 			AvoidBuggyIPs: p.AvoidBuggyIPs,
+			AutoAssign:    autoAssign,
 		}
 		cfg.Pools[p.Name] = pool
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,6 +55,7 @@ address-pools:
   - 10.20.0.0/16
   - 10.50.0.0/24
   avoid-buggy-ips: true
+  auto-assign: false
   advertisements:
   - aggregation-length: 32
     localpref: 100
@@ -85,6 +86,7 @@ address-pools:
 					"pool1": &Pool{
 						CIDR:          []*net.IPNet{ipnet("10.20.0.0/16"), ipnet("10.50.0.0/24")},
 						AvoidBuggyIPs: true,
+						AutoAssign: false,
 						Advertisements: []*Advertisement{
 							{
 								AggregationLength: 32,
@@ -102,6 +104,7 @@ address-pools:
 					},
 					"pool2": &Pool{
 						CIDR: []*net.IPNet{ipnet("30.0.0.0/8")},
+						AutoAssign: true,
 					},
 				},
 			},
@@ -195,7 +198,9 @@ address-pools:
 `,
 			want: &Config{
 				Pools: map[string]*Pool{
-					"pool1": &Pool{},
+					"pool1": &Pool{
+						AutoAssign: true,
+					},
 				},
 			},
 		},
@@ -231,6 +236,7 @@ address-pools:
 			want: &Config{
 				Pools: map[string]*Pool{
 					"pool1": &Pool{
+						AutoAssign: true,
 						Advertisements: []*Advertisement{
 							{
 								AggregationLength: 32,

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -43,6 +43,10 @@ data:
       # smurf protection. Such devices have become fairly rare, but
       # the option is here if you encounter serving issues.
       avoid-buggy-ips: true
+      # (optional) If false, MetalLB will not automatically allocate
+      # any address in this pool. Addresses can still explicitly be
+      # requested via loadBalancerIP or the address-pool annotation.
+      # auto-assign: false
       # A list of BGP advertisements to make. Each address that gets
       # assigned out of this pool will turn into this many
       # advertisements. For most simple setups, you'll probably just

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -43,9 +43,9 @@ data:
       # smurf protection. Such devices have become fairly rare, but
       # the option is here if you encounter serving issues.
       avoid-buggy-ips: true
-      # (optional) If false, MetalLB will not automatically allocate
-      # any address in this pool. Addresses can still explicitly be
-      # requested via loadBalancerIP or the address-pool annotation.
+      # (optional, default true) If false, MetalLB will not automatically
+      # allocate any address in this pool. Addresses can still explicitly
+      # be requested via loadBalancerIP or the address-pool annotation.
       auto-assign: false
       # A list of BGP advertisements to make. Each address that gets
       # assigned out of this pool will turn into this many

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -46,7 +46,7 @@ data:
       # (optional) If false, MetalLB will not automatically allocate
       # any address in this pool. Addresses can still explicitly be
       # requested via loadBalancerIP or the address-pool annotation.
-      # auto-assign: false
+      auto-assign: false
       # A list of BGP advertisements to make. Each address that gets
       # assigned out of this pool will turn into this many
       # advertisements. For most simple setups, you'll probably just

--- a/website/content/usage.md
+++ b/website/content/usage.md
@@ -83,6 +83,34 @@ spec:
   type: LoadBalancer
 ```
 
+## Control automatic address pool allocation
+
+In some environments, you'll have some large address pools of "cheap" IPs
+(e.g. RFC1918), and some smaller pools of "expensive" IPs (e.g. public
+IPv4 addresses leased on the grey market).
+
+By default, MetalLB will allocate IPs from any configured address pool
+with free addresses. This might end up using "expensive" addresses for
+services that don't require it.
+
+To prevent this behaviour you can disable automatic allocation for a pool
+by setting the `auto-assign` flag to `false`:
+
+```yaml
+# Rest of config omitted for brevity
+address-pools:
+- name: cheap
+  cidr:
+  - 192.168.144.0/20
+- name: expensive
+  cidr:
+  - 42.176.25.64/30
+  auto-assign: false
+```
+
+Addresses can still be specifically allocated from the "expensive" pool
+with the methods described in the "Requesting specific IPs" section above.
+
 ## Traffic policies
 
 MetalLB respects the service's `externalTrafficPolicy` option, and


### PR DESCRIPTION
**What this PR does / why we need it**:
A proposed implementation of the "disable auto assign" feature brought up in #4 

**Which issue(s) this PR fixes**:
Fixes #4 

**Special notes for your reviewer**:
Defaulting the flag to true required some changes in the test configurations. Maybe it would be cleaner to name it `disable-auto-assign` so we can go with the zero bool value if the flag has not been set in the YAML?