### PR TITLE
arp-speaker: less spammy logs

### DIFF
--- a/arp-speaker/main.go
+++ b/arp-speaker/main.go
@@ -104,6 +104,10 @@ func (c *controller) SetBalancer(name string, svc *v1.Service, eps *v1.Endpoints
 }
 
 func (c *controller) deleteBalancer(name, reason string) error {
+	if !c.ann.AnnounceName(name) {
+		return nil
+	}
+
 	glog.Infof("%s: stopping announcements, %s", name, reason)
 	c.announcing.Delete(prometheus.Labels{
 		"service": name,

--- a/internal/arp/arp.go
+++ b/internal/arp/arp.go
@@ -118,6 +118,14 @@ func (a *Announce) Announce(ip net.IP) bool {
 	return false
 }
 
+// AnnounceName returns true when we have an announcement under name.
+func (a *Announce) AnnounceName(name string) bool {
+	a.RLock()
+	defer a.RUnlock()
+	_, ok := a.ips[name]
+	return ok
+}
+
 // Unsolicited returns a slice of ARP responses that can be send out as unsolicited ARPs.
 func (a *Announce) Unsolicited() []*arp.Packet {
 	a.RLock()


### PR DESCRIPTION
When deleting an LB check if we even have an LB for that name in the
first place; if so, short circuit and don't log anything.