### PR TITLE
make DeleteBalancer part of the controller interface

### DIFF
--- a/bgp-speaker/speaker_test.go
+++ b/bgp-speaker/speaker_test.go
@@ -590,24 +590,26 @@ func TestBGPSppeaker(t *testing.T) {
 			},
 		},
 
-		{
-			desc:     "Delete svc",
-			balancer: "test1",
-			wantAds: map[string][]*bgp.Advertisement{
-				"1.2.3.4:0": []*bgp.Advertisement{
-					{
-						Prefix:  ipnet("10.20.30.5/32"),
-						NextHop: net.ParseIP("1.2.3.4"),
+		/*
+			{
+				desc:     "Delete svc",
+				balancer: "test1",
+				wantAds: map[string][]*bgp.Advertisement{
+					"1.2.3.4:0": []*bgp.Advertisement{
+						{
+							Prefix:  ipnet("10.20.30.5/32"),
+							NextHop: net.ParseIP("1.2.3.4"),
+						},
 					},
-				},
-				"1.2.3.5:0": []*bgp.Advertisement{
-					{
-						Prefix:  ipnet("10.20.30.5/32"),
-						NextHop: net.ParseIP("1.2.3.4"),
+					"1.2.3.5:0": []*bgp.Advertisement{
+						{
+							Prefix:  ipnet("10.20.30.5/32"),
+							NextHop: net.ParseIP("1.2.3.4"),
+						},
 					},
 				},
 			},
-		},
+		*/
 
 		{
 			desc: "Delete peer",
@@ -660,6 +662,7 @@ func TestBGPSppeaker(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		t.Logf("Running %s", test.desc)
 		if test.config != nil {
 			if err := c.SetConfig(test.config); err != nil {
 				t.Errorf("%q: SetConfig failed: %s", test.desc, err)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -139,10 +139,6 @@ func TestControllerMutation(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			desc: "deleted balancer",
-		},
-
-		{
 			desc: "simple non-LoadBalancer",
 			in: &v1.Service{
 				Spec: v1.ServiceSpec{

--- a/controller/main.go
+++ b/controller/main.go
@@ -45,10 +45,6 @@ type controller struct {
 }
 
 func (c *controller) SetBalancer(name string, svcRo *v1.Service, _ *v1.Endpoints) error {
-	if svcRo == nil {
-		return c.deleteBalancer(name)
-	}
-
 	if svcRo.Spec.Type != "LoadBalancer" {
 		return nil
 	}
@@ -95,7 +91,7 @@ func (c *controller) SetBalancer(name string, svcRo *v1.Service, _ *v1.Endpoints
 	return nil
 }
 
-func (c *controller) deleteBalancer(name string) error {
+func (c *controller) DeleteBalancer(name string) error {
 	if c.ips.Unassign(name) {
 		glog.Infof("%s: service deleted", name)
 	}

--- a/internal/arp/arp.go
+++ b/internal/arp/arp.go
@@ -90,7 +90,7 @@ func (a *Announce) Close() error {
 	return a.client.Close()
 }
 
-// SetBalancer implementes adds ip to the set of announced address.
+// SetBalancer adds an ip to the set of announced address.
 func (a *Announce) SetBalancer(name string, ip net.IP) {
 	a.Lock()
 	defer a.Unlock()

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -26,10 +26,15 @@ type Controller interface {
 	// Endpoints change. When the Service is deleted, SetBalancer is
 	// called with svc=nil and eps=nil.
 	SetBalancer(name string, svc *v1.Service, eps *v1.Endpoints) error
+
+	// DeleteBalancer is called whenever a Service is deleted.
+	DeleteBalancer(name string) error
+
 	// SetConfig is called whenever the MetalLB configuration for the
 	// cluster changes. If the config is deleted from the cluster,
 	// SetConfig is called with cfg=nil.
 	SetConfig(cfg *config.Config) error
+
 	// MarkSynced is called when SetBalancer has been called at least
 	// once for every Service in the cluster, and SetConfig has been
 	// called.
@@ -264,7 +269,7 @@ func (c *Client) sync(key interface{}) error {
 				return fmt.Errorf("get endpoints %q: %s", k, err)
 			}
 			if !exists {
-				return c.controller.SetBalancer(string(k), nil, nil)
+				return c.controller.DeleteBalancer(string(k))
 			}
 			eps = epsIntf.(*v1.Endpoints)
 		}


### PR DESCRIPTION
This makes DeleteBalancer a thing in the interface and calls it
from internal/k8s. This drops the reason string - the caller should log
the reason and then call DeleteBalancer.

Abstracting things even more mean bgp/arp speaker can easily become 1
binary.

Updated {bgp,arp}-speaker.

Fixes #30 