### PR TITLE
Correctly parse things

### DIFF
--- a/speaker/arp_controller.go
+++ b/speaker/arp_controller.go
@@ -89,7 +89,7 @@ func (c *arpController) SetBalancer(name string, svc *v1.Service, eps *v1.Endpoi
 	}
 
 	if pool.Protocol != config.ARP {
-		glog.Errorf("%s: protocol in pool is not set to %s, got %s", name, pool.Protocol, string(config.BGP), pool.Protocol)
+		glog.Errorf("%s: protocol in pool is not set to %s, got %s", name, string(config.ARP), pool.Protocol)
 		return nil
 	}
 

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -99,7 +99,7 @@ func (c *bgpController) SetBalancer(name string, svc *v1.Service, eps *v1.Endpoi
 	}
 
 	if pool.Protocol != config.BGP {
-		glog.Errorf("%s: protocol in pool is not set to %s, got %s", name, pool.Protocol, string(config.BGP), pool.Protocol)
+		glog.Errorf("%s: protocol in pool is not set to %s, got %s", name, string(config.BGP), pool.Protocol)
 		return nil
 	}
 


### PR DESCRIPTION
Protocol in the config wasn't parsed at all, leading to the default of bgp.

Fix this.