### PR TITLE
Split makefile push and set-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ push-manifests:
 .PHONY: push
 push: gen-image-targets
 	+make -f $(MK_IMAGE_TARGETS) $(foreach bin,$(BINARIES),$(bin)/$(ARCH))
+
+.PHONY: set-image
+set-image:
 	kubectl set image -n metallb-system deploy/controller controller=$(IN_CLUSTER_REGISTRY)/controller:$(TAG)-$(ARCH)
 	kubectl set image -n metallb-system ds/speaker speaker=$(IN_CLUSTER_REGISTRY)/speaker:$(TAG)-$(ARCH)
 	kubectl set image -n metallb-system deploy/test-bgp-router test-bgp-router=$(IN_CLUSTER_REGISTRY)/test-bgp-router:$(TAG)-$(ARCH)


### PR DESCRIPTION
If I push, say amd64, I don't want set-image because these images
will be of the wrong arch. Split the targets
