### PR TITLE
Arp network

### DIFF
--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -10,11 +10,11 @@ import (
 func TestAssignment(t *testing.T) {
 	alloc := New()
 	if err := alloc.SetPools(map[string]*config.Pool{
-		"test": &config.Pool{
+		"test": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.4/31")},
 		},
-		"test2": &config.Pool{
+		"test2": {
 			AvoidBuggyIPs: true,
 			AutoAssign:    true,
 			CIDR:          []*net.IPNet{ipnet("1.2.4.0/24")},
@@ -125,15 +125,15 @@ func TestPoolAllocation(t *testing.T) {
 	// out of IPs quickly even though there are tons available in
 	// other pools.
 	if err := alloc.SetPools(map[string]*config.Pool{
-		"not_this_one": &config.Pool{
+		"not_this_one": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("192.168.0.0/16")},
 		},
-		"test": &config.Pool{
+		"test": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.4/31"), ipnet("1.2.3.10/31")},
 		},
-		"test2": &config.Pool{
+		"test2": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("10.20.30.0/24")},
 		},
@@ -206,11 +206,11 @@ func TestPoolAllocation(t *testing.T) {
 func TestAllocation(t *testing.T) {
 	alloc := New()
 	if err := alloc.SetPools(map[string]*config.Pool{
-		"test1": &config.Pool{
+		"test1": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.4/31")},
 		},
-		"test2": &config.Pool{
+		"test2": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.10/31")},
 		},
@@ -278,20 +278,20 @@ func TestAllocation(t *testing.T) {
 func TestBuggyIPs(t *testing.T) {
 	alloc := New()
 	if err := alloc.SetPools(map[string]*config.Pool{
-		"test": &config.Pool{
+		"test": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.0/31")},
 		},
-		"test2": &config.Pool{
+		"test2": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.254/31")},
 		},
-		"test3": &config.Pool{
+		"test3": {
 			AvoidBuggyIPs: true,
 			AutoAssign:    true,
 			CIDR:          []*net.IPNet{ipnet("1.2.4.0/31")},
 		},
-		"test4": &config.Pool{
+		"test4": {
 			AvoidBuggyIPs: true,
 			AutoAssign:    true,
 			CIDR:          []*net.IPNet{ipnet("1.2.4.254/31")},
@@ -347,20 +347,20 @@ func TestBuggyIPs(t *testing.T) {
 func TestARPForbidden(t *testing.T) {
 	alloc := New()
 	if err := alloc.SetPools(map[string]*config.Pool{
-		"test": &config.Pool{
+		"test": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.0/31")},
 		},
-		"test2": &config.Pool{
+		"test2": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.254/31")},
 		},
-		"test3": &config.Pool{
+		"test3": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.4.0/31")},
 			ARPNetwork: ipnet("1.2.4.0/24"),
 		},
-		"test4": &config.Pool{
+		"test4": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.4.254/31")},
 			ARPNetwork: ipnet("1.2.4.0/24"),
@@ -441,7 +441,7 @@ func TestNextIP(t *testing.T) {
 func TestConfigReload(t *testing.T) {
 	alloc := New()
 	if err := alloc.SetPools(map[string]*config.Pool{
-		"test": &config.Pool{
+		"test": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.0/30")},
 		},
@@ -461,7 +461,7 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "set same config is no-op",
 			pools: map[string]*config.Pool{
-				"test": &config.Pool{
+				"test": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.0/30")},
 				},
@@ -471,7 +471,7 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "expand pool",
 			pools: map[string]*config.Pool{
-				"test": &config.Pool{
+				"test": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.0/24")},
 				},
@@ -481,7 +481,7 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "shrink pool",
 			pools: map[string]*config.Pool{
-				"test": &config.Pool{
+				"test": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.0/30")},
 				},
@@ -491,7 +491,7 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "can't shrink further",
 			pools: map[string]*config.Pool{
-				"test": &config.Pool{
+				"test": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.2/31")},
 				},
@@ -502,7 +502,7 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "rename the pool",
 			pools: map[string]*config.Pool{
-				"test2": &config.Pool{
+				"test2": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.0/30")},
 				},
@@ -512,11 +512,11 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "split pool",
 			pools: map[string]*config.Pool{
-				"test": &config.Pool{
+				"test": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.0/31")},
 				},
-				"test2": &config.Pool{
+				"test2": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.2/31")},
 				},
@@ -526,11 +526,11 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "swap pool names",
 			pools: map[string]*config.Pool{
-				"test2": &config.Pool{
+				"test2": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.0/31")},
 				},
-				"test": &config.Pool{
+				"test": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.2/31")},
 				},
@@ -540,7 +540,7 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "delete used pool",
 			pools: map[string]*config.Pool{
-				"test": &config.Pool{
+				"test": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.2/31")},
 				},
@@ -551,7 +551,7 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "delete unused pool",
 			pools: map[string]*config.Pool{
-				"test2": &config.Pool{
+				"test2": {
 					AutoAssign: true,
 					CIDR:       []*net.IPNet{ipnet("1.2.3.0/31")},
 				},
@@ -561,7 +561,7 @@ func TestConfigReload(t *testing.T) {
 		{
 			desc: "enable buggy IPs not allowed",
 			pools: map[string]*config.Pool{
-				"test2": &config.Pool{
+				"test2": {
 					AutoAssign:    true,
 					AvoidBuggyIPs: true,
 					CIDR:          []*net.IPNet{ipnet("1.2.3.0/31")},
@@ -591,11 +591,11 @@ func TestConfigReload(t *testing.T) {
 func TestAutoAssign(t *testing.T) {
 	alloc := New()
 	if err := alloc.SetPools(map[string]*config.Pool{
-		"test1": &config.Pool{
+		"test1": {
 			AutoAssign: false,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.4/31")},
 		},
-		"test2": &config.Pool{
+		"test2": {
 			AutoAssign: true,
 			CIDR:       []*net.IPNet{ipnet("1.2.3.10/31")},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,7 +69,13 @@ address-pools:
 - name: pool3
   protocol: arp
   cidr:
-  - 40.0.0.0/16
+  - 40.0.0.0/25
+- name: pool4
+  protocol: arp
+  cidr:
+  - 50.0.0.0/16
+  - 50.20.0.0/24
+  arp-network: 50.0.0.0/8
 `,
 			want: &Config{
 				Peers: []*Peer{
@@ -122,14 +128,15 @@ address-pools:
 					},
 					"pool3": {
 						Protocol:   ARP,
-						CIDR:       []*net.IPNet{ipnet("40.0.0.0/16")},
+						CIDR:       []*net.IPNet{ipnet("40.0.0.0/25")},
 						AutoAssign: true,
-						BGPAdvertisements: []*BGPAdvertisement{
-							{
-								AggregationLength: 32,
-								Communities:       map[uint32]bool{},
-							},
-						},
+						ARPNetwork: ipnet("40.0.0.0/24"),
+					},
+					"pool4": {
+						Protocol:   ARP,
+						CIDR:       []*net.IPNet{ipnet("50.0.0.0/16"), ipnet("50.20.0.0/24")},
+						AutoAssign: true,
+						ARPNetwork: ipnet("50.0.0.0/8"),
 					},
 				},
 			},

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -76,6 +76,17 @@ data:
         communities:
         - 64512:1
         - no-export
+      # (optional) The full network over which MetalLB is advertising
+      # with ARP. All CIDRs (above) in this address pool must be
+      # contained in this network. MetalLB will not allocate the
+      # network and broadcast IPs of this network, even if they are
+      # contained in one of the available CIDR prefixes.
+      #
+      # The default value for this field is the /24 network that
+      # contains all of this pool's CIDR prefixes. If no such /24
+      # exists because the CIDRs span multiple /24s, arp-network must
+      # be explicitly specified.
+      arp-network: 192.168.0.0/24
     # (optional) BGP community aliases. Instead of using hard to
     # read BGP community numbers in address pool advertisement
     # configurations, you can define alias names here and use those


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the `arp-network` pool attribute, and teaches MetalLB to not allocate network+broadcast IPs in ARP mode.

**Which issue(s) this PR fixes**
Fixes #110 