### PR TITLE
leadership monitoring

### DIFF
--- a/internal/k8s/leader.go
+++ b/internal/k8s/leader.go
@@ -20,6 +20,8 @@ func (c *Client) NewLeaderElector(a *arp.Announce, identity string) (*le.LeaderE
 		return nil, err
 	}
 
+	leader.Set(-1)
+
 	lec := le.LeaderElectionConfig{
 		Lock:          lock,
 		LeaseDuration: 30 * time.Minute,
@@ -28,10 +30,12 @@ func (c *Client) NewLeaderElector(a *arp.Announce, identity string) (*le.LeaderE
 		Callbacks: le.LeaderCallbacks{
 			OnStartedLeading: func(stop <-chan struct{}) {
 				glog.Infof("Acquiring leadership")
+				leader.Set(1)
 				a.Acquire()
 			},
 			OnStoppedLeading: func() {
 				glog.Infof("Lost leadership")
+				leader.Set(0)
 				a.Relinquish()
 			},
 		},

--- a/internal/k8s/stats.go
+++ b/internal/k8s/stats.go
@@ -30,6 +30,13 @@ var (
 		Name:      "config_stale_bool",
 		Help:      "1 if running on a stale configuration, because the latest config failed to load.",
 	})
+
+	leader = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "metallb",
+		Subsystem: "k8s_client",
+		Name:      "leadership_bool",
+		Help:      "1 if leader, 0 if not, -1 if never been a leader.",
+	})
 )
 
 func init() {
@@ -37,4 +44,5 @@ func init() {
 	prometheus.MustRegister(updateErrors)
 	prometheus.MustRegister(configLoaded)
 	prometheus.MustRegister(configStale)
+	prometheus.MustRegister(leader)
 }


### PR DESCRIPTION
Add Gauge to tell what binary has won the leadership election.
Gauge is 1 when leader, 0 when not and initially set to -1 (never leader
or not interested.)