### PR TITLE
Fix usage doc service example: "annotations" field should be part of …

### DIFF
--- a/website/content/usage/_index.md
+++ b/website/content/usage/_index.md
@@ -71,8 +71,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx
-annotations:
-  metallb.universe.tf/address-pool: production-public-ips
+  annotations:
+    metallb.universe.tf/address-pool: production-public-ips
 spec:
   ports:
   - port: 80


### PR DESCRIPTION
…ObjectMeta, not Service.

**What this PR does / why we need it**:
The "Service" yaml example in the documentation cannot be deployed as is.

**Special notes for your reviewer**:
