### PR TITLE
Fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MetalLB is a load-balancer implementation for bare
 metal [Kubernetes](https://kubernetes.io) clusters, using standard
 routing protocols.
 
-[![Project maturity: alpha](https://img.shields.io/badge/maturity-alpha-yellow.svg)](https://metallb.universe.tf/maturity/) [![license](https://img.shields.io/github/license/google/metallb.svg?maxAge=2592000)](https://github.com/google/netboot/blob/master/LICENSE) [![CircleCI](https://img.shields.io/circleci/project/github/google/metallb.svg)](https://circleci.com/gh/google/metallb) [![Containers](https://img.shields.io/badge/containers-ready-green.svg)](https://hub.docker.com/u/metallb) [![Go report card](https://goreportcard.com/badge/github.com/google/metallb)](https://goreportcard.com/report/github.com/google/metallb)
+[![Project maturity: alpha](https://img.shields.io/badge/maturity-alpha-yellow.svg)](https://metallb.universe.tf/maturity/) [![license](https://img.shields.io/github/license/google/metallb.svg?maxAge=2592000)](https://github.com/google/metallb/blob/master/LICENSE) [![CircleCI](https://img.shields.io/circleci/project/github/google/metallb.svg)](https://circleci.com/gh/google/metallb) [![Containers](https://img.shields.io/badge/containers-ready-green.svg)](https://hub.docker.com/u/metallb) [![Go report card](https://goreportcard.com/badge/github.com/google/metallb)](https://goreportcard.com/report/github.com/google/metallb)
 
 Check out [MetalLB's website](https://metallb.universe.tf) for more
 information.


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the license link.

It was pointing to google/netboot instead of the google/metallb repository.

**Special notes for your reviewer**:
🖨️🍝