### PR TITLE
Give each instance of speaker a unique identity for leader election.

### DIFF
--- a/internal/k8s/leader.go
+++ b/internal/k8s/leader.go
@@ -24,10 +24,17 @@ func (c *Client) NewLeaderElector(a *arp.Announce, lockName string, identity str
 	leader.Set(-1)
 
 	lec := le.LeaderElectionConfig{
-		Lock:          lock,
-		LeaseDuration: 30 * time.Minute,
-		RenewDeadline: 10 * time.Second,
-		RetryPeriod:   5 * time.Second,
+		Lock: lock,
+		// Time before the lock expires and other replicas can try to
+		// become leader.
+		LeaseDuration: 10 * time.Second,
+		// Elected leader refreshes the lock this often. It should be
+		// less than LeaseDuration, so that even if there is clock
+		// skew in the cluster the leader can keep their lock.
+		RenewDeadline: 5 * time.Second,
+		// Time to wait between operation retries, if we get an error
+		// back.
+		RetryPeriod: 1 * time.Second,
 		Callbacks: le.LeaderCallbacks{
 			OnStartedLeading: func(stop <-chan struct{}) {
 				glog.Infof("Host %s acquiring leadership", hostname)

--- a/internal/k8s/leader.go
+++ b/internal/k8s/leader.go
@@ -14,9 +14,9 @@ import (
 )
 
 // NewLeaderElector returns a new LeaderElector used for endpoint leader election using c.
-func (c *Client) NewLeaderElector(a *arp.Announce, identity string) (*le.LeaderElector, error) {
+func (c *Client) NewLeaderElector(a *arp.Announce, lockName string, identity string) (*le.LeaderElector, error) {
 	conf := rl.ResourceLockConfig{Identity: identity, EventRecorder: &noopEvent{}}
-	lock, err := rl.New(rl.EndpointsResourceLock, "metallb-system", identity, c.client.CoreV1(), conf)
+	lock, err := rl.New(rl.EndpointsResourceLock, "metallb-system", lockName, c.client.CoreV1(), conf)
 	if err != nil {
 		return nil, err
 	}

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -83,7 +83,7 @@ func main() {
 		glog.Fatalf("Error getting k8s client: %s", err)
 	}
 
-	le, err := client.NewLeaderElector(cARP.ann, speaker, myIP.String())
+	le, err := client.NewLeaderElector(cARP.ann, speaker)
 	if err != nil {
 		glog.Fatalf("Error setting up leader election: %s", err)
 	}

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -83,7 +83,7 @@ func main() {
 		glog.Fatalf("Error getting k8s client: %s", err)
 	}
 
-	le, err := client.NewLeaderElector(cARP.ann, speaker)
+	le, err := client.NewLeaderElector(cARP.ann, speaker, myIP.String())
 	if err != nil {
 		glog.Fatalf("Error setting up leader election: %s", err)
 	}


### PR DESCRIPTION
Each replica of speaker must have a distinct identity for leader election, because that's the key they use to decide who is master. We were accidentally setting the identity to the same thing in all instances of speaker, so they all "became" leader simultaneously.