### PR TITLE
vendor: add github.com/mikioh/ipaddr

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8bb945fe537562d5949d17b3ba2be39bb4ffe8c0e66d311394ca2d255545c2a8
-updated: 2018-01-19T02:05:28.169212885-05:00
+hash: 37c9208efe97a24ed06a0086cb4323aaf1b0bfb9f163368244579feb8439e64d
+updated: 2018-01-25T14:07:32.773491185-05:00
 imports:
 - name: github.com/armon/go-radix
   version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
@@ -118,6 +118,8 @@ imports:
   version: 43aea02eeef3a76c02084be996a86130c6bbb231
 - name: github.com/mdlayher/raw
   version: 9df8b4265df2bcf01458b1759cf7ec4b81b50b65
+- name: github.com/mikioh/ipaddr
+  version: ef85e35a1b1801b80c891a443c8b68f100095452
 - name: github.com/mitchellh/mapstructure
   version: 06020f85339e21b2478f756a78e295255ffa4d6a
 - name: github.com/osrg/gobgp

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,8 @@
 package: go.universe.tf/metallb
 import:
 - package: github.com/golang/glog
+- package: github.com/mikioh/ipaddr
+  version: ef85e35a1b1801b80c891a443c8b68f100095452
 - package: github.com/mdlayher/arp
 - package: github.com/mdlayher/ethernet
 - package: github.com/mdlayher/ndp

--- a/vendor/github.com/mikioh/ipaddr/.gitignore
+++ b/vendor/github.com/mikioh/ipaddr/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/mikioh/ipaddr/.travis.yml
+++ b/vendor/github.com/mikioh/ipaddr/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+
+os:
+- linux
+- osx
+
+go:
+- 1.8.5
+- 1.9.2
+- tip
+
+script:
+- go test -v -race
+- go test -v -run=none -bench=. -benchmem
+
+notifications:
+  email: false

--- a/vendor/github.com/mikioh/ipaddr/LICENSE
+++ b/vendor/github.com/mikioh/ipaddr/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2014, Mikio Hara
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/mikioh/ipaddr/README.md
+++ b/vendor/github.com/mikioh/ipaddr/README.md
@@ -1,0 +1,7 @@
+Package ipaddr provides basic functions for the manipulation of IP address prefixes and subsequent addresses as described in RFC 4632 and RFC 4291.
+
+[![GoDoc](https://godoc.org/github.com/mikioh/ipaddr?status.png)](https://godoc.org/github.com/mikioh/ipaddr)
+[![Build Status](https://travis-ci.org/mikioh/ipaddr.svg?branch=master)](https://travis-ci.org/mikioh/ipaddr)
+[![Build status](https://ci.appveyor.com/api/projects/status/euop45j45ble7yh8?svg=true)](https://ci.appveyor.com/project/mikioh/ipaddr)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mikioh/ipaddr)](https://goreportcard.com/report/github.com/mikioh/ipaddr)
+

--- a/vendor/github.com/mikioh/ipaddr/appveyor.yml
+++ b/vendor/github.com/mikioh/ipaddr/appveyor.yml
@@ -1,0 +1,17 @@
+version: "{build}"
+
+branches:
+  only:
+    - master
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - mkdir c:\gopath
+  - go get github.com/mikioh/ipaddr
+
+build_script:
+  - go test -v -race
+  - go test -v -run=none -bench=. -benchmem

--- a/vendor/github.com/mikioh/ipaddr/benchmark_test.go
+++ b/vendor/github.com/mikioh/ipaddr/benchmark_test.go
@@ -1,0 +1,255 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/mikioh/ipaddr"
+)
+
+var (
+	aggregatablePrefixesIPv4 = toPrefixes([]string{
+		"192.0.2.0/28", "192.0.2.16/28", "192.0.2.32/28", "192.0.2.48/28",
+		"192.0.2.64/28", "192.0.2.80/28", "192.0.2.96/28", "192.0.2.112/28",
+		"192.0.2.128/28", "192.0.2.144/28", "192.0.2.160/28", "192.0.2.176/28",
+		"192.0.2.192/28", "192.0.2.208/28", "192.0.2.224/28", "192.0.2.240/28",
+		"198.51.100.0/24", "203.0.113.0/24",
+	})
+	aggregatablePrefixesIPv6 = toPrefixes([]string{
+		"2001:db8::/64", "2001:db8:0:1::/64", "2001:db8:0:2::/64", "2001:db8:0:3::/64",
+		"2001:db8:0:4::/64", "2001:db8:0:5::/64", "2001:db8:0:6::/64", "2001:db8:0:7::/64",
+		"2001:db8:cafe::/64", "2001:db8:babe::/64",
+	})
+)
+
+func BenchmarkAggregate(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		ps   []ipaddr.Prefix
+	}{
+		{"IPv4", aggregatablePrefixesIPv4},
+		{"IPv6", aggregatablePrefixesIPv6},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ipaddr.Aggregate(bb.ps)
+			}
+		})
+	}
+}
+
+func BenchmarkCompare(b *testing.B) {
+	for _, bb := range []struct {
+		name   string
+		px, py *ipaddr.Prefix
+	}{
+		{"IPv4", toPrefix("192.0.2.0/25"), toPrefix("192.0.2.128/25")},
+		{"IPv6", toPrefix("2001:db8:f001:f002::/64"), toPrefix("2001:db8:f001:f003::/64")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ipaddr.Compare(bb.px, bb.py)
+			}
+		})
+	}
+}
+
+func BenchmarkSummarize(b *testing.B) {
+	for _, bb := range []struct {
+		name     string
+		fip, lip net.IP
+	}{
+		{"IPv4", net.IPv4(192, 0, 2, 1), net.IPv4(192, 0, 2, 255)},
+		{"IPv6", net.ParseIP("2001:db8::1"), net.ParseIP("2001:db8::00ff")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ipaddr.Summarize(bb.fip, bb.lip)
+			}
+		})
+	}
+}
+
+func BenchmarkSupernet(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		ps   []ipaddr.Prefix
+	}{
+		{"IPv4", aggregatablePrefixesIPv4},
+		{"IPv6", aggregatablePrefixesIPv6},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ipaddr.Supernet(bb.ps)
+			}
+		})
+	}
+}
+
+func BenchmarkCursorNext(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		c    *ipaddr.Cursor
+	}{
+		{"IPv4", ipaddr.NewCursor(toPrefixes([]string{"192.0.2.0/24"}))},
+		{"IPv6", ipaddr.NewCursor(toPrefixes([]string{"2001:db8::/120"}))},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for bb.c.Next() != nil {
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCursorPrev(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		c    *ipaddr.Cursor
+	}{
+		{"IPv4", ipaddr.NewCursor(toPrefixes([]string{"192.0.2.255/24"}))},
+		{"IPv6", ipaddr.NewCursor(toPrefixes([]string{"2001:db8::ff/120"}))},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for bb.c.Prev() != nil {
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixEqual(b *testing.B) {
+	for _, bb := range []struct {
+		name   string
+		px, py *ipaddr.Prefix
+	}{
+		{"IPv4", toPrefix("192.0.2.0/25"), toPrefix("192.0.2.128/25")},
+		{"IPv6", toPrefix("2001:db8:f001:f002::/64"), toPrefix("2001:db8:f001:f003::/64")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bb.px.Equal(bb.py)
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixExclude(b *testing.B) {
+	for _, bb := range []struct {
+		name   string
+		px, py *ipaddr.Prefix
+	}{
+		{"IPv4", toPrefix("192.0.2.0/24"), toPrefix("192.0.2.192/32")},
+		{"IPv6", toPrefix("2001:db8::/120"), toPrefix("2001:db8::1/128")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bb.px.Exclude(bb.py)
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixMarshalBinary(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		p    *ipaddr.Prefix
+	}{
+		{"IPv4", toPrefix("192.0.2.0/31")},
+		{"IPv6", toPrefix("2001:db8:cafe:babe::/127")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bb.p.MarshalBinary()
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixMarshalText(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		p    *ipaddr.Prefix
+	}{
+		{"IPv4", toPrefix("192.0.2.0/31")},
+		{"IPv6", toPrefix("2001:db8:cafe:babe::/127")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bb.p.MarshalText()
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixOverlaps(b *testing.B) {
+	for _, bb := range []struct {
+		name   string
+		px, py *ipaddr.Prefix
+	}{
+		{"IPv4", toPrefix("192.0.2.0/25"), toPrefix("192.0.2.128/25")},
+		{"IPv6", toPrefix("2001:db8:f001:f002::/64"), toPrefix("2001:db8:f001:f003::/64")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bb.px.Overlaps(bb.py)
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixSubnets(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		p    *ipaddr.Prefix
+	}{
+		{"IPv4", toPrefix("192.0.2.0/24")},
+		{"IPv6", toPrefix("2001:db8::/32")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bb.p.Subnets(3)
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixUnmarshalBinary(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		p    *ipaddr.Prefix
+		nlri []byte
+	}{
+		{"IPv4", toPrefix("0.0.0.0/0"), []byte{22, 192, 168, 0}},
+		{"IPv6", toPrefix("::/0"), []byte{66, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0xca, 0xfe, 0x80}},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bb.p.UnmarshalBinary(bb.nlri)
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixUnmarshalTextIPv4(b *testing.B) {
+	for _, bb := range []struct {
+		name string
+		p    *ipaddr.Prefix
+		lit  []byte
+	}{
+		{"IPv4", toPrefix("0.0.0.0/0"), []byte("192.168.0.0/31")},
+		{"IPv6", toPrefix("::/0"), []byte("2001:db8:cafe:babe::/127")},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bb.p.UnmarshalText(bb.lit)
+			}
+		})
+	}
+}

--- a/vendor/github.com/mikioh/ipaddr/cursor.go
+++ b/vendor/github.com/mikioh/ipaddr/cursor.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr
+
+import (
+	"errors"
+	"net"
+)
+
+// A Cursor repesents a movable indicator on a single or multiple
+// prefixes.
+type Cursor struct {
+	curr, start, end ipv6Int
+	pi               int
+	ps               []Prefix
+}
+
+func (c *Cursor) set(pi int, ip net.IP) {
+	c.pi = pi
+	c.curr = ipToIPv6Int(ip.To16())
+	c.start = ipToIPv6Int(c.ps[c.pi].IP.To16())
+	if ip.To4() != nil {
+		c.end = c.ps[c.pi].lastIPv4MappedIPv6Int()
+	}
+	if ip.To16() != nil && ip.To4() == nil {
+		c.end = c.ps[c.pi].lastIPv6Int()
+	}
+}
+
+// First returns the start position on c.
+func (c *Cursor) First() *Position {
+	return &Position{IP: c.ps[0].IP, Prefix: c.ps[0]}
+}
+
+// Last returns the end position on c.
+func (c *Cursor) Last() *Position {
+	return &Position{IP: c.ps[len(c.ps)-1].Last(), Prefix: c.ps[len(c.ps)-1]}
+}
+
+// List returns the list of prefixes on c.
+func (c *Cursor) List() []Prefix {
+	return c.ps
+}
+
+// Next turns to the next position on c.
+// It returns nil at the end on c.
+func (c *Cursor) Next() *Position {
+	n := c.curr.cmp(&c.end)
+	if n == 0 {
+		if c.pi == len(c.ps)-1 {
+			return nil
+		}
+		c.pi++
+		c.curr = ipToIPv6Int(c.ps[c.pi].IP.To16())
+		c.start = c.curr
+		if c.ps[c.pi].IP.To4() != nil {
+			c.end = c.ps[c.pi].lastIPv4MappedIPv6Int()
+		}
+		if c.ps[c.pi].IP.To16() != nil && c.ps[c.pi].IP.To4() == nil {
+			c.end = c.ps[c.pi].lastIPv6Int()
+		}
+	} else {
+		c.curr.incr()
+	}
+	return c.Pos()
+}
+
+// Pos returns the current position on c.
+func (c *Cursor) Pos() *Position {
+	return &Position{IP: c.curr.ip(), Prefix: c.ps[c.pi]}
+}
+
+// Prev turns to the previous position on c.
+// It returns nil at the start on c.
+func (c *Cursor) Prev() *Position {
+	n := c.curr.cmp(&c.start)
+	if n == 0 {
+		if c.pi == 0 {
+			return nil
+		}
+		c.pi--
+		if c.ps[c.pi].IP.To4() != nil {
+			c.curr = c.ps[c.pi].lastIPv4MappedIPv6Int()
+			c.end = c.curr
+		}
+		if c.ps[c.pi].IP.To16() != nil && c.ps[c.pi].IP.To4() == nil {
+			c.curr = c.ps[c.pi].lastIPv6Int()
+			c.end = c.curr
+		}
+		c.start = ipToIPv6Int(c.ps[c.pi].IP.To16())
+	} else {
+		c.curr.decr()
+	}
+	return c.Pos()
+}
+
+// Reset resets all state and switches to ps.
+// It uses the existing prefixes when ps is nil.
+func (c *Cursor) Reset(ps []Prefix) {
+	ps = newSortedPrefixes(ps, sortAscending, false)
+	if len(ps) > 0 {
+		c.ps = ps
+	}
+	c.set(0, c.ps[0].IP.To16())
+}
+
+// Set sets the current position on c to pos.
+func (c *Cursor) Set(pos *Position) error {
+	if pos == nil {
+		return errors.New("invalid position")
+	}
+	pi := -1
+	for i, p := range c.ps {
+		if p.Equal(&pos.Prefix) {
+			pi = i
+			break
+		}
+	}
+	if pi == -1 || !c.ps[pi].IPNet.Contains(pos.IP) {
+		return errors.New("position out of range")
+	}
+	c.set(pi, pos.IP.To16())
+	return nil
+}
+
+// NewCursor returns a new cursor.
+func NewCursor(ps []Prefix) *Cursor {
+	ps = newSortedPrefixes(ps, sortAscending, false)
+	if len(ps) == 0 {
+		return nil
+	}
+	c := &Cursor{ps: ps}
+	c.set(0, c.ps[0].IP.To16())
+	return c
+}

--- a/vendor/github.com/mikioh/ipaddr/cursor_test.go
+++ b/vendor/github.com/mikioh/ipaddr/cursor_test.go
@@ -1,0 +1,398 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr_test
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/mikioh/ipaddr"
+)
+
+func TestCursorFirstLastIP(t *testing.T) {
+	for i, tt := range []struct {
+		in          []ipaddr.Prefix
+		first, last net.IP
+	}{
+		// IPv4 prefixes
+		{
+			toPrefixes([]string{
+				"0.0.0.0/0",
+				"255.255.255.255/32",
+			}),
+			net.ParseIP("0.0.0.0"),
+			net.ParseIP("255.255.255.255"),
+		},
+		{
+			toPrefixes([]string{
+				"192.168.0.0/32", "192.168.0.1/32", "192.168.0.2/32", "192.168.0.3/32",
+				"192.168.4.0/24", "192.168.0.0/32", "192.168.0.1/32",
+			}),
+			net.ParseIP("192.168.0.0"),
+			net.ParseIP("192.168.4.255"),
+		},
+		{
+			toPrefixes([]string{"192.168.0.1/32"}),
+			net.ParseIP("192.168.0.1"),
+			net.ParseIP("192.168.0.1"),
+		},
+
+		// IPv6 prefixes
+		{
+			toPrefixes([]string{
+				"::/0",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128",
+			}),
+			net.ParseIP("::"),
+			net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+		},
+		{
+			toPrefixes([]string{
+				"2001:db8::/64", "2001:db8:0:1::/64", "2001:db8:0:2::/64", "2001:db8:0:3::/64",
+				"2001:db8:0:4::/64", "2001:db8::/64", "2001:db8::1/64",
+			}),
+			net.ParseIP("2001:db8::"),
+			net.ParseIP("2001:db8:0:4:ffff:ffff:ffff:ffff"),
+		},
+		{
+			toPrefixes([]string{"2001:db8::1/128"}),
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("2001:db8::1"),
+		},
+
+		// Mixed prefixes
+		{
+			toPrefixes([]string{
+				"192.168.0.1/32",
+				"2001:db8::1/64",
+				"192.168.255.0/24",
+			}),
+			net.ParseIP("192.168.0.1"),
+			net.ParseIP("2001:db8::ffff:ffff:ffff:ffff"),
+		},
+	} {
+		c := ipaddr.NewCursor(tt.in)
+		fpos, lpos := c.First(), c.Last()
+		if !tt.first.Equal(fpos.IP) || !tt.last.Equal(lpos.IP) {
+			t.Errorf("#%d: got %v, %v; want %v, %v", i, fpos.IP, lpos.IP, tt.first, tt.last)
+		}
+	}
+}
+
+func TestCursorFirstLastPrefix(t *testing.T) {
+	for i, tt := range []struct {
+		in          []ipaddr.Prefix
+		first, last *ipaddr.Prefix
+	}{
+		// IPv4 prefixes
+		{
+			toPrefixes([]string{
+				"0.0.0.0/0",
+				"255.255.255.255/32",
+			}),
+			toPrefix("0.0.0.0/0"),
+			toPrefix("255.255.255.255/32"),
+		},
+		{
+			toPrefixes([]string{
+				"192.168.0.0/32", "192.168.0.1/32", "192.168.0.2/32", "192.168.0.3/32",
+				"192.168.4.0/24", "192.168.0.0/32", "192.168.0.1/32",
+			}),
+			toPrefix("192.168.0.0/32"),
+			toPrefix("192.168.4.0/24"),
+		},
+
+		// IPv6 prefixes
+		{
+			toPrefixes([]string{
+				"::/0",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128",
+			}),
+			toPrefix("::/0"),
+			toPrefix("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"),
+		},
+		{
+			toPrefixes([]string{
+				"2001:db8::/64", "2001:db8:0:1::/64", "2001:db8:0:2::/64", "2001:db8:0:3::/64",
+				"2001:db8:0:4::/64", "2001:db8::/64", "2001:db8::1/64",
+			}),
+			toPrefix("2001:db8::/64"),
+			toPrefix("2001:db8:0:4::/64"),
+		},
+
+		// Mixed prefixes
+		{
+			toPrefixes([]string{
+				"192.168.0.1/32",
+				"2001:db8::1/64",
+				"192.168.255.0/24",
+			}),
+			toPrefix("192.168.0.1/32"),
+			toPrefix("2001:db8::/64"),
+		},
+	} {
+		c := ipaddr.NewCursor(tt.in)
+		fpos, lpos := c.First(), c.Last()
+		if !tt.first.Equal(&fpos.Prefix) || !tt.last.Equal(&lpos.Prefix) {
+			t.Errorf("#%d: got %v, %v; want %v, %v", i, fpos.Prefix, lpos.Prefix, tt.first, tt.last)
+		}
+	}
+}
+
+func TestCursorPrevNext(t *testing.T) {
+	for i, tt := range []struct {
+		ps               []ipaddr.Prefix
+		in, pwant, nwant *ipaddr.Position
+	}{
+		// IPv4 prefixes
+		{
+			toPrefixes([]string{"192.168.0.0/24"}),
+			toPosition("192.168.0.0", "192.168.0.0/24"),
+			nil,
+			toPosition("192.168.0.1", "192.168.0.0/24"),
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24"}),
+			toPosition("192.168.0.255", "192.168.0.0/24"),
+			toPosition("192.168.0.254", "192.168.0.0/24"),
+			nil,
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "192.168.1.0/24"}),
+			toPosition("192.168.0.255", "192.168.0.0/24"),
+			toPosition("192.168.0.254", "192.168.0.0/24"),
+			toPosition("192.168.1.0", "192.168.1.0/24"),
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "192.168.1.0/24"}),
+			toPosition("192.168.1.0", "192.168.1.0/24"),
+			toPosition("192.168.0.255", "192.168.0.0/24"),
+			toPosition("192.168.1.1", "192.168.1.0/24"),
+		},
+
+		// IPv6 prefixes
+		{
+			toPrefixes([]string{"2001:db8::/64"}),
+			toPosition("2001:db8::", "2001:db8::/64"),
+			nil,
+			toPosition("2001:db8::1", "2001:db8::/64"),
+		},
+		{
+			toPrefixes([]string{"2001:db8::/64"}),
+			toPosition("2001:db8::ffff:ffff:ffff:ffff", "2001:db8::/64"),
+			toPosition("2001:db8::ffff:ffff:ffff:fffe", "2001:db8::/64"),
+			nil,
+		},
+		{
+			toPrefixes([]string{"2001:db8::/64", "2001:db8:1::/64"}),
+			toPosition("2001:db8::ffff:ffff:ffff:ffff", "2001:db8::/64"),
+			toPosition("2001:db8::ffff:ffff:ffff:fffe", "2001:db8::/64"),
+			toPosition("2001:db8:1::", "2001:db8:1::/64"),
+		},
+		{
+			toPrefixes([]string{"2001:db8::/64", "2001:db8:1::/64"}),
+			toPosition("2001:db8:1::", "2001:db8:1::/64"),
+			toPosition("2001:db8::ffff:ffff:ffff:ffff", "2001:db8::/64"),
+			toPosition("2001:db8:1::1", "2001:db8:1::/64"),
+		},
+
+		// Mixed prefixes
+		{
+			toPrefixes([]string{"192.168.0.0/24", "2001:db8::/64"}),
+			toPosition("2001:db8::ffff:ffff:ffff:ffff", "2001:db8::/64"),
+			toPosition("2001:db8::ffff:ffff:ffff:fffe", "2001:db8::/64"),
+			nil,
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "2001:db8::/64"}),
+			toPosition("192.168.0.255", "192.168.0.0/24"),
+			toPosition("192.168.0.254", "192.168.0.0/24"),
+			toPosition("2001:db8::", "2001:db8::/64"),
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "::/64"}),
+			toPosition("192.168.0.255", "192.168.0.0/24"),
+			toPosition("192.168.0.254", "192.168.0.0/24"),
+			nil,
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "::/64"}),
+			toPosition("::ffff:ffff:ffff:ffff", "::/64"),
+			toPosition("::ffff:ffff:ffff:fffe", "::/64"),
+			toPosition("192.168.0.0", "192.168.0.0/24"),
+		},
+	} {
+		c := ipaddr.NewCursor(tt.ps)
+		if err := c.Set(tt.in); err != nil {
+			t.Fatal(err)
+		}
+		out := c.Prev()
+		if !reflect.DeepEqual(out, tt.pwant) {
+			t.Errorf("#%d: got %v; want %v", i, out, tt.pwant)
+		}
+		if err := c.Set(tt.in); err != nil {
+			t.Fatal(err)
+		}
+		out = c.Next()
+		if !reflect.DeepEqual(out, tt.nwant) {
+			t.Errorf("#%d: got %v; want %v", i, out, tt.nwant)
+		}
+	}
+}
+
+func TestCursorReset(t *testing.T) {
+	for i, tt := range []struct {
+		in  []ipaddr.Prefix
+		out *ipaddr.Position
+	}{
+		// IPv4 prefixes
+		{
+			toPrefixes([]string{"192.168.0.0/24"}),
+			toPosition("192.168.0.0", "192.168.0.0/24"),
+		},
+
+		// IPv6 prefixes
+		{
+			toPrefixes([]string{"2001:db8::/64"}),
+			toPosition("2001:db8::", "2001:db8::/64"),
+		},
+
+		// Mixed prefixes
+		{
+			toPrefixes([]string{"192.168.0.0/24", "2001:db8::/64"}),
+			toPosition("192.168.0.0", "192.168.0.0/24"),
+		},
+
+		{
+			nil,
+			toPosition("0.0.0.0", "0.0.0.0/0"),
+		},
+	} {
+		in := toPrefixes([]string{"0.0.0.0/0"})
+		c := ipaddr.NewCursor(in)
+		c.Reset(tt.in)
+		if !reflect.DeepEqual(c.Pos(), tt.out) {
+			t.Errorf("#%d: got %v; want %v", i, c.Pos(), tt.out)
+		}
+	}
+}
+
+func TestCursorPos(t *testing.T) {
+	for i, tt := range []struct {
+		ps []ipaddr.Prefix
+		in *ipaddr.Position
+		error
+	}{
+		// IPv4 prefixes
+		{
+			toPrefixes([]string{"192.168.0.0/24", "192.168.1.0/24", "192.168.2.0/24"}),
+			toPosition("192.168.1.1", "192.168.1.0/24"),
+			nil,
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "192.168.1.0/24", "192.168.2.0/24"}),
+			toPosition("192.168.3.1", "192.168.1.0/24"),
+			errors.New("should fail"),
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "192.168.1.0/24", "192.168.2.0/24"}),
+			toPosition("192.168.1.1", "192.168.3.0/24"),
+			errors.New("should fail"),
+		},
+
+		// IPv6 prefixes
+		{
+			toPrefixes([]string{"2001:db8::/64", "2001:db8:1::/64", "2001:db8:2::/64"}),
+			toPosition("2001:db8:1::1", "2001:db8:1::/64"),
+			nil,
+		},
+		{
+			toPrefixes([]string{"2001:db8::/64", "2001:db8:1::/64", "2001:db8:2::/64"}),
+			toPosition("2001:db8:3::1", "2001:db8:1::/64"),
+			errors.New("should fail"),
+		},
+		{
+			toPrefixes([]string{"2001:db8::/64", "2001:db8:1::/64", "2001:db8:2::/64"}),
+			toPosition("2001:db8:1::1", "2001:db8:3::/64"),
+			errors.New("should fail"),
+		},
+
+		// Mixed prefixes
+		{
+			toPrefixes([]string{"192.168.0.0/24", "2001:db8::/64"}),
+			toPosition("192.168.0.1", "192.168.0.0/24"),
+			nil,
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "2001:db8::/64"}),
+			toPosition("2001:db8::1", "2001:db8::/64"),
+			nil,
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "2001:db8::/64"}),
+			toPosition("2001:db8::1", "192.168.0.0/24"),
+			errors.New("should fail"),
+		},
+		{
+			toPrefixes([]string{"192.168.0.0/24", "2001:db8::/64"}),
+			toPosition("192.168.0.1", "2001:db8::/64"),
+			errors.New("should fail"),
+		},
+	} {
+		c := ipaddr.NewCursor(tt.ps)
+		err := c.Set(tt.in)
+		if err != nil && tt.error == nil {
+			t.Errorf("#%d: got %v; want %v", i, err, tt.error)
+		}
+		if err != nil {
+			continue
+		}
+		if !reflect.DeepEqual(c.Pos(), tt.in) {
+			t.Errorf("#%d: got %v; want %v", i, c.Pos(), tt.in)
+		}
+	}
+}
+
+func TestNewCursor(t *testing.T) {
+	for i, tt := range []struct {
+		in []string
+	}{
+		// IPv4 prefixes
+		{
+			[]string{
+				"192.168.0.0/32", "192.168.0.1/32", "192.168.0.2/32", "192.168.0.3/32",
+				"192.168.4.0/24", "192.168.0.0/32", "192.168.0.1/32",
+			},
+		},
+
+		// IPv6 prefixes
+		{
+			[]string{
+				"2001:db8::/64", "2001:db8:0:1::/64", "2001:db8:0:2::/64", "2001:db8:0:3::/64",
+				"2001:db8:0:4::/64", "2001:db8::/64", "2001:db8::1/64",
+			},
+		},
+
+		// Mixed prefixes
+		{
+			[]string{
+				"192.168.0.0/32", "192.168.0.1/32", "192.168.0.2/32", "192.168.0.3/32",
+				"192.168.4.0/24", "192.168.0.0/32", "192.168.0.1/32", "2001:db8::/64",
+				"2001:db8:0:1::/64", "2001:db8:0:2::/64", "2001:db8:0:3::/64", "2001:db8:0:4::/64",
+				"2001:db8::/64", "2001:db8::1/64",
+			},
+		},
+	} {
+		in, orig := toPrefixes(tt.in), toPrefixes(tt.in)
+		ipaddr.NewCursor(in)
+		if !reflect.DeepEqual(in, orig) {
+			t.Errorf("#%d: %v is corrupted; want %v", i, in, orig)
+		}
+	}
+
+	ipaddr.NewCursor(nil)
+}

--- a/vendor/github.com/mikioh/ipaddr/doc.go
+++ b/vendor/github.com/mikioh/ipaddr/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+/*
+Package ipaddr provides basic functions for the manipulation of IP
+address prefixes and subsequent addresses as described in RFC 4632 and
+RFC 4291.
+*/
+package ipaddr

--- a/vendor/github.com/mikioh/ipaddr/example_test.go
+++ b/vendor/github.com/mikioh/ipaddr/example_test.go
@@ -1,0 +1,157 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr_test
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/mikioh/ipaddr"
+)
+
+func ExampleCursor_traversal() {
+	c, err := ipaddr.Parse("2001:db8::/126,192.0.2.128/30,198.51.100.0/29")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(c.Pos(), c.First(), c.Last(), c.List())
+	for pos := c.Next(); pos != nil; pos = c.Next() {
+		fmt.Println(pos)
+	}
+	fmt.Println(c.Pos(), c.First(), c.Last(), c.List())
+	for pos := c.Prev(); pos != nil; pos = c.Prev() {
+		fmt.Println(pos)
+	}
+	fmt.Println(c.Pos(), c.First(), c.Last(), c.List())
+	// Output:
+	// &{192.0.2.128 192.0.2.128/30} &{192.0.2.128 192.0.2.128/30} &{2001:db8::3 2001:db8::/126} [192.0.2.128/30 198.51.100.0/29 2001:db8::/126]
+	// &{192.0.2.129 192.0.2.128/30}
+	// &{192.0.2.130 192.0.2.128/30}
+	// &{192.0.2.131 192.0.2.128/30}
+	// &{198.51.100.0 198.51.100.0/29}
+	// &{198.51.100.1 198.51.100.0/29}
+	// &{198.51.100.2 198.51.100.0/29}
+	// &{198.51.100.3 198.51.100.0/29}
+	// &{198.51.100.4 198.51.100.0/29}
+	// &{198.51.100.5 198.51.100.0/29}
+	// &{198.51.100.6 198.51.100.0/29}
+	// &{198.51.100.7 198.51.100.0/29}
+	// &{2001:db8:: 2001:db8::/126}
+	// &{2001:db8::1 2001:db8::/126}
+	// &{2001:db8::2 2001:db8::/126}
+	// &{2001:db8::3 2001:db8::/126}
+	// &{2001:db8::3 2001:db8::/126} &{192.0.2.128 192.0.2.128/30} &{2001:db8::3 2001:db8::/126} [192.0.2.128/30 198.51.100.0/29 2001:db8::/126]
+	// &{2001:db8::2 2001:db8::/126}
+	// &{2001:db8::1 2001:db8::/126}
+	// &{2001:db8:: 2001:db8::/126}
+	// &{198.51.100.7 198.51.100.0/29}
+	// &{198.51.100.6 198.51.100.0/29}
+	// &{198.51.100.5 198.51.100.0/29}
+	// &{198.51.100.4 198.51.100.0/29}
+	// &{198.51.100.3 198.51.100.0/29}
+	// &{198.51.100.2 198.51.100.0/29}
+	// &{198.51.100.1 198.51.100.0/29}
+	// &{198.51.100.0 198.51.100.0/29}
+	// &{192.0.2.131 192.0.2.128/30}
+	// &{192.0.2.130 192.0.2.128/30}
+	// &{192.0.2.129 192.0.2.128/30}
+	// &{192.0.2.128 192.0.2.128/30}
+	// &{192.0.2.128 192.0.2.128/30} &{192.0.2.128 192.0.2.128/30} &{2001:db8::3 2001:db8::/126} [192.0.2.128/30 198.51.100.0/29 2001:db8::/126]
+}
+
+func ExamplePrefix_subnettingAndSupernetting() {
+	_, n, err := net.ParseCIDR("203.0.113.0/24")
+	if err != nil {
+		log.Fatal(err)
+	}
+	p := ipaddr.NewPrefix(n)
+	fmt.Println(p.IP, p.Last(), p.Len(), p.Mask, p.Hostmask())
+	fmt.Println()
+	ps := p.Subnets(3)
+	for _, p := range ps {
+		fmt.Println(p)
+	}
+	fmt.Println()
+	fmt.Println(ipaddr.Supernet(ps))
+	fmt.Println(ipaddr.Supernet(ps[1:7]))
+	fmt.Println(ipaddr.Supernet(ps[:4]))
+	fmt.Println(ipaddr.Supernet(ps[4:8]))
+	// Output:
+	// 203.0.113.0 203.0.113.255 24 ffffff00 000000ff
+	//
+	// 203.0.113.0/27
+	// 203.0.113.32/27
+	// 203.0.113.64/27
+	// 203.0.113.96/27
+	// 203.0.113.128/27
+	// 203.0.113.160/27
+	// 203.0.113.192/27
+	// 203.0.113.224/27
+	//
+	// 203.0.113.0/24
+	// 203.0.113.0/24
+	// 203.0.113.0/25
+	// 203.0.113.128/25
+}
+
+func ExamplePrefix_subnettingAndAggregation() {
+	_, n, err := net.ParseCIDR("192.0.2.0/24")
+	if err != nil {
+		log.Fatal(err)
+	}
+	p := ipaddr.NewPrefix(n)
+	fmt.Println(p.IP, p.Last(), p.Len(), p.Mask, p.Hostmask())
+	fmt.Println()
+	ps := p.Subnets(3)
+	for _, p := range ps {
+		fmt.Println(p)
+	}
+	fmt.Println()
+	fmt.Println(ipaddr.Aggregate(ps))
+	fmt.Println(ipaddr.Aggregate(ps[1:7]))
+	fmt.Println(ipaddr.Aggregate(ps[:4]))
+	fmt.Println(ipaddr.Aggregate(ps[4:8]))
+	// Output:
+	// 192.0.2.0 192.0.2.255 24 ffffff00 000000ff
+	//
+	// 192.0.2.0/27
+	// 192.0.2.32/27
+	// 192.0.2.64/27
+	// 192.0.2.96/27
+	// 192.0.2.128/27
+	// 192.0.2.160/27
+	// 192.0.2.192/27
+	// 192.0.2.224/27
+	//
+	// [192.0.2.0/24]
+	// [192.0.2.32/27 192.0.2.64/26 192.0.2.128/26 192.0.2.192/27]
+	// [192.0.2.0/25]
+	// [192.0.2.128/25]
+}
+
+func ExamplePrefix_addressRangeSummarization() {
+	ps := ipaddr.Summarize(net.ParseIP("2001:db8::1"), net.ParseIP("2001:db8::8000"))
+	for _, p := range ps {
+		fmt.Println(p)
+	}
+	// Output:
+	// 2001:db8::1/128
+	// 2001:db8::2/127
+	// 2001:db8::4/126
+	// 2001:db8::8/125
+	// 2001:db8::10/124
+	// 2001:db8::20/123
+	// 2001:db8::40/122
+	// 2001:db8::80/121
+	// 2001:db8::100/120
+	// 2001:db8::200/119
+	// 2001:db8::400/118
+	// 2001:db8::800/117
+	// 2001:db8::1000/116
+	// 2001:db8::2000/115
+	// 2001:db8::4000/114
+	// 2001:db8::8000/128
+}

--- a/vendor/github.com/mikioh/ipaddr/heap_test.go
+++ b/vendor/github.com/mikioh/ipaddr/heap_test.go
@@ -1,0 +1,37 @@
+// Copyright 2013 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr_test
+
+import (
+	"container/heap"
+	"net"
+	"testing"
+
+	"github.com/mikioh/ipaddr"
+)
+
+type prefixHeap []ipaddr.Prefix
+
+func (h *prefixHeap) Less(i, j int) bool   { return ipaddr.Compare(&(*h)[i], &(*h)[j]) < 0 }
+func (h *prefixHeap) Swap(i, j int)        { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
+func (h *prefixHeap) Len() int             { return len(*h) }
+func (h *prefixHeap) Pop() (v interface{}) { *h, v = (*h)[:h.Len()-1], (*h)[h.Len()-1]; return }
+func (h *prefixHeap) Push(v interface{})   { *h = append(*h, v.(ipaddr.Prefix)) }
+
+func TestPrefixHeap(t *testing.T) {
+	_, n, err := net.ParseCIDR("2001:db8:f001::/48")
+	if err != nil {
+		t.Fatal(err)
+	}
+	super := ipaddr.NewPrefix(n)
+	h := new(prefixHeap)
+	heap.Init(h)
+	for _, p := range super.Subnets(6) {
+		heap.Push(h, p)
+	}
+	for h.Len() > 0 {
+		heap.Pop(h)
+	}
+}

--- a/vendor/github.com/mikioh/ipaddr/helper.go
+++ b/vendor/github.com/mikioh/ipaddr/helper.go
@@ -1,0 +1,13 @@
+// Copyright 2013 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr
+
+func mask32(nbits int) uint32 {
+	return -uint32(1 << uint(32-nbits))
+}
+
+func mask64(nbits int) uint64 {
+	return -uint64(1 << uint(64-nbits))
+}

--- a/vendor/github.com/mikioh/ipaddr/helper_go1_8.go
+++ b/vendor/github.com/mikioh/ipaddr/helper_go1_8.go
@@ -1,0 +1,43 @@
+// Copyright 2013 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+// +build !go1.9
+
+package ipaddr
+
+func leadingZeros32(bs uint32) int {
+	bs |= bs >> 1
+	bs |= bs >> 2
+	bs |= bs >> 4
+	bs |= bs >> 8
+	bs |= bs >> 16
+	return npop32(^bs)
+}
+
+func leadingZeros64(bs uint64) int {
+	bs |= bs >> 1
+	bs |= bs >> 2
+	bs |= bs >> 4
+	bs |= bs >> 8
+	bs |= bs >> 16
+	bs |= bs >> 32
+	return npop64(^bs)
+}
+
+func npop32(bs uint32) int {
+	bs = bs&0x55555555 + bs>>1&0x55555555
+	bs = bs&0x33333333 + bs>>2&0x33333333
+	bs = bs&0x0f0f0f0f + bs>>4&0x0f0f0f0f
+	bs = bs&0x00ff00ff + bs>>8&0x00ff00ff
+	return int(bs&0x0000ffff + bs>>16&0x0000ffff)
+}
+
+func npop64(bs uint64) int {
+	bs = bs&0x5555555555555555 + bs>>1&0x5555555555555555
+	bs = bs&0x3333333333333333 + bs>>2&0x3333333333333333
+	bs = bs&0x0f0f0f0f0f0f0f0f + bs>>4&0x0f0f0f0f0f0f0f0f
+	bs = bs&0x00ff00ff00ff00ff + bs>>8&0x00ff00ff00ff00ff
+	bs = bs&0x0000ffff0000ffff + bs>>16&0x0000ffff0000ffff
+	return int(bs&0x00000000ffffffff + bs>>32&0x00000000ffffffff)
+}

--- a/vendor/github.com/mikioh/ipaddr/helper_go1_9.go
+++ b/vendor/github.com/mikioh/ipaddr/helper_go1_9.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+// +build go1.9
+
+package ipaddr
+
+import "math/bits"
+
+func leadingZeros32(bs uint32) int {
+	return int(bits.LeadingZeros32(bs))
+}
+
+func leadingZeros64(bs uint64) int {
+	return int(bits.LeadingZeros64(bs))
+}

--- a/vendor/github.com/mikioh/ipaddr/parse.go
+++ b/vendor/github.com/mikioh/ipaddr/parse.go
@@ -1,0 +1,72 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ipaddr
+
+import (
+	"net"
+	"strings"
+)
+
+// Parse parses s as a single or combination of multiple IP addresses
+// and IP address prefixes.
+//
+// Examples:
+//
+//	Parse("192.0.2.1")
+//	Parse("2001:db8::1/128")
+//	Parse("203.0.113.0/24")
+//	Parse("192.0.2.1,2001:db8::1/128,203.0.113.0/24")
+func Parse(s string) (*Cursor, error) {
+	poss, ps, err := parseMulti(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(ps) == 1 {
+		c := NewCursor(ps)
+		if err := c.Set(&poss[0]); err != nil {
+			return nil, err
+		}
+		return c, nil
+	}
+	return NewCursor(ps), nil
+}
+
+func parseMulti(s string) ([]Position, []Prefix, error) {
+	ss := strings.Split(s, ",")
+	var poss []Position
+	var ps []Prefix
+	for _, s := range ss {
+		s = strings.TrimSpace(s)
+		pos, p, err := parse(s)
+		if err != nil {
+			return nil, nil, err
+		}
+		poss = append(poss, *pos)
+		ps = append(ps, *p)
+	}
+	return poss, ps, nil
+}
+
+func parse(s string) (*Position, *Prefix, error) {
+	ip, n, err := net.ParseCIDR(s)
+	if err == nil {
+		p := NewPrefix(n)
+		pos := Position{IP: ip, Prefix: *p}
+		return &pos, p, nil
+	}
+	ip = net.ParseIP(s)
+	if ip == nil {
+		return nil, nil, &net.AddrError{Err: "invalid address", Addr: s}
+	}
+	var m net.IPMask
+	if ip.To4() != nil {
+		m = net.CIDRMask(IPv4PrefixLen, IPv4PrefixLen)
+	}
+	if ip.To16() != nil && ip.To4() == nil {
+		m = net.CIDRMask(IPv6PrefixLen, IPv6PrefixLen)
+	}
+	p := NewPrefix(&net.IPNet{IP: ip, Mask: m})
+	return &Position{IP: ip, Prefix: *p}, p, nil
+}

--- a/vendor/github.com/mikioh/ipaddr/parse_test.go
+++ b/vendor/github.com/mikioh/ipaddr/parse_test.go
@@ -1,0 +1,134 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ipaddr_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mikioh/ipaddr"
+)
+
+func TestParse(t *testing.T) {
+	for i, tt := range []struct {
+		in  string
+		pos *ipaddr.Position
+		ps  []ipaddr.Prefix
+	}{
+		// IPv4 addresses, prefixes
+		{
+			"192.168.0.1",
+			toPosition("192.168.0.1", "192.168.0.1/32"),
+			toPrefixes([]string{
+				"192.168.0.1/32",
+			}),
+		},
+		{
+			"192.168.0.1/32",
+			toPosition("192.168.0.1", "192.168.0.1/32"),
+			toPrefixes([]string{
+				"192.168.0.1/32",
+			}),
+		},
+		{
+			"192.168.0.1/24",
+			toPosition("192.168.0.1", "192.168.0.0/24"),
+			toPrefixes([]string{
+				"192.168.0.0/24",
+			}),
+		},
+		{
+			"192.168.0.2,192.168.0.2/24",
+			toPosition("192.168.0.0", "192.168.0.0/24"),
+			toPrefixes([]string{
+				"192.168.0.0/24",
+				"192.168.0.2/32",
+			}),
+		},
+		{
+			"192.168.0.2/24,192.168.0.2",
+			toPosition("192.168.0.0", "192.168.0.0/24"),
+			toPrefixes([]string{
+				"192.168.0.0/24",
+				"192.168.0.2/32",
+			}),
+		},
+
+		// IPv6 addresses, prefixes
+		{
+			"2001:db8::1",
+			toPosition("2001:db8::1", "2001:db8::1/128"),
+			toPrefixes([]string{
+				"2001:db8::1/128",
+			}),
+		},
+		{
+			"2001:db8::1/128",
+			toPosition("2001:db8::1", "2001:db8::1/128"),
+			toPrefixes([]string{
+				"2001:db8::1/128",
+			}),
+		},
+		{
+			"2001:db8::1/64",
+			toPosition("2001:db8::1", "2001:db8::/64"),
+			toPrefixes([]string{
+				"2001:db8::/64",
+			}),
+		},
+		{
+			"2001:db8::2,2001:db8::2/64",
+			toPosition("2001:db8::", "2001:db8::/64"),
+			toPrefixes([]string{
+				"2001:db8::/64",
+				"2001:db8::2/128",
+			}),
+		},
+		{
+			"2001:db8::2/64,2001:db8::2",
+			toPosition("2001:db8::", "2001:db8::/64"),
+			toPrefixes([]string{
+				"2001:db8::/64",
+				"2001:db8::2/128",
+			}),
+		},
+
+		// Mixed addresses, prefixes
+		{
+			"192.168.0.3,192.168.0.3/24,172.16.0.0/16,2001:db8::3,2001:db8::3/64",
+			toPosition("172.16.0.0", "172.16.0.0/16"),
+			toPrefixes([]string{
+				"172.16.0.0/16",
+				"192.168.0.0/24",
+				"192.168.0.3/32",
+				"2001:db8::/64",
+				"2001:db8::3/128",
+			}),
+		},
+		{
+			"2001:db8::3,2001:db8::3/64,192.168.0.3,192.168.0.3/24,172.16.0.0/16",
+			toPosition("172.16.0.0", "172.16.0.0/16"),
+			toPrefixes([]string{
+				"172.16.0.0/16",
+				"192.168.0.0/24",
+				"192.168.0.3/32",
+				"2001:db8::/64",
+				"2001:db8::3/128",
+			}),
+		},
+	} {
+		out, err := ipaddr.Parse(tt.in)
+		if err != nil {
+			t.Errorf("#%d: %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(out.Pos(), tt.pos) {
+			t.Errorf("#%d: got %v; want %v", i, out.Pos(), tt.pos)
+		}
+		if !reflect.DeepEqual(out.List(), tt.ps) {
+			t.Errorf("#%d: got %v; want %v", i, out.List(), tt.ps)
+		}
+	}
+}

--- a/vendor/github.com/mikioh/ipaddr/position.go
+++ b/vendor/github.com/mikioh/ipaddr/position.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr
+
+import "net"
+
+// A Position represents a position on IP address space.
+type Position struct {
+	IP     net.IP // IP address
+	Prefix Prefix // IP address prefix
+}
+
+// IsBroadcast reports whether p is an IPv4 directed or limited
+// broadcast address.
+func (p *Position) IsBroadcast() bool {
+	return !p.IP.IsUnspecified() && !p.IP.IsMulticast() && p.IP.To4() != nil && (p.IP.Equal(net.IPv4bcast) || p.IP.Equal(p.Prefix.Last()))
+}
+
+// IsSubnetRouterAnycast reports whether p is an IPv6 subnet router
+// anycast address.
+func (p *Position) IsSubnetRouterAnycast() bool {
+	return !p.IP.IsUnspecified() && !p.IP.IsLoopback() && !p.IP.IsMulticast() && p.IP.To16() != nil && p.IP.To4() == nil && p.IP.Equal(p.Prefix.IP)
+}

--- a/vendor/github.com/mikioh/ipaddr/position_test.go
+++ b/vendor/github.com/mikioh/ipaddr/position_test.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/mikioh/ipaddr"
+)
+
+func toPosition(s1, s2 string) *ipaddr.Position {
+	if s1 == "" || s2 == "" {
+		return nil
+	}
+	return &ipaddr.Position{IP: net.ParseIP(s1), Prefix: *toPrefix(s2)}
+}
+
+func TestPositionIsBroadcast(t *testing.T) {
+	for i, tt := range []struct {
+		in *ipaddr.Position
+		ok bool
+	}{
+		{toPosition("192.168.0.255", "192.168.0.0/24"), true},
+		{toPosition("255.255.255.255", "0.0.0.0/0"), true},
+
+		{toPosition("192.168.0.0", "192.168.0.0/24"), false},
+		{toPosition("224.0.0.0", "224.0.0.0/4"), false},
+		{toPosition("239.255.255.255", "224.0.0.0/4"), false},
+		{toPosition("0.0.0.0", "0.0.0.0/0"), false},
+
+		{toPosition("2001:db8::", "2001:db8::/64"), false},
+		{toPosition("2001:db8::ffff:ffff:ffff:ffff", "2001:db8::/64"), false},
+		{toPosition("ff00::", "ff00::/8"), false},
+		{toPosition("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ff00::/8"), false},
+		{toPosition("::1", "::1/128"), false},
+		{toPosition("::", "::/0"), false},
+	} {
+		if ok := tt.in.IsBroadcast(); ok != tt.ok {
+			t.Errorf("#%d: got %v for %v; want %v", i, ok, tt.in, tt.ok)
+		}
+	}
+}
+
+func TestPositionIsSubnetRouterAnycast(t *testing.T) {
+	for i, tt := range []struct {
+		in *ipaddr.Position
+		ok bool
+	}{
+		{toPosition("2001:db8::", "2001:db8::/64"), true},
+
+		{toPosition("2001:db8::ffff:ffff:ffff:ffff", "2001:db8::/64"), false},
+		{toPosition("ff00::", "ff00::/8"), false},
+		{toPosition("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ff00::/8"), false},
+		{toPosition("::1", "::1/128"), false},
+		{toPosition("::", "::/0"), false},
+
+		{toPosition("192.168.0.0", "192.168.0.0/24"), false},
+		{toPosition("192.168.0.255", "192.168.0.0/24"), false},
+		{toPosition("255.255.255.255", "0.0.0.0/0"), false},
+		{toPosition("224.0.0.0", "224.0.0.0/4"), false},
+		{toPosition("239.255.255.255", "224.0.0.0/4"), false},
+		{toPosition("0.0.0.0", "0.0.0.0/0"), false},
+	} {
+		if ok := tt.in.IsSubnetRouterAnycast(); ok != tt.ok {
+			t.Errorf("#%d: got %v for %v; want %v", i, ok, tt.in, tt.ok)
+		}
+	}
+}

--- a/vendor/github.com/mikioh/ipaddr/prefix.go
+++ b/vendor/github.com/mikioh/ipaddr/prefix.go
@@ -1,0 +1,708 @@
+// Copyright 2013 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr
+
+import (
+	"encoding"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+)
+
+var (
+	_ encoding.BinaryMarshaler   = &Prefix{}
+	_ encoding.BinaryUnmarshaler = &Prefix{}
+	_ encoding.TextMarshaler     = &Prefix{}
+	_ encoding.TextUnmarshaler   = &Prefix{}
+
+	_ fmt.Stringer = &Prefix{}
+)
+
+const (
+	IPv4PrefixLen = 8 * net.IPv4len // maximum number of prefix length in bits
+	IPv6PrefixLen = 8 * net.IPv6len // maximum number of prefix length in bits
+)
+
+// A Prefix represents an IP address prefix.
+type Prefix struct {
+	net.IPNet
+}
+
+func (p *Prefix) lastIPv4Int() ipv4Int {
+	return ipToIPv4Int(p.IP) | ipv4Int(^mask32(p.Len()))
+}
+
+func (p *Prefix) lastIPv4MappedIPv6Int() ipv6Int {
+	i4 := ipToIPv4Int(p.IP) | ipv4Int(^mask32(p.Len()))
+	var i6 ipv6Int
+	i6[1] = 0x0000ffff00000000 | uint64(i4)
+	return i6
+}
+
+func (p *Prefix) lastIPv6Int() ipv6Int {
+	i := ipToIPv6Int(p.IP)
+	var m ipv6Int
+	m.invmask(p.Len())
+	i[0], i[1] = i[0]|m[0], i[1]|m[1]
+	return i
+}
+
+// Contains reports whether q is a subnetwork of p.
+func (p *Prefix) Contains(q *Prefix) bool {
+	if p.IP.To4() != nil {
+		return p.containsIPv4(q)
+	}
+	if p.IP.To16() != nil && p.IP.To4() == nil {
+		return p.containsIPv6(q)
+	}
+	return false
+}
+
+func (p *Prefix) containsIPv4(q *Prefix) bool {
+	if q.IP.To4() == nil {
+		return false
+	}
+	l := p.Len()
+	if l >= q.Len() {
+		return false
+	}
+	base := ipToIPv4Int(p.IP.Mask(p.Mask))
+	mask := ipMaskToIPv4Int(p.Mask)
+	fip := ipToIPv4Int(q.IP)
+	lip := q.lastIPv4Int()
+	fdiff := uint32((base ^ fip) & mask)
+	ldiff := uint32((base ^ lip) & mask)
+	return leadingZeros32(fdiff) >= l && leadingZeros32(ldiff) >= l
+}
+
+func (p *Prefix) containsIPv6(q *Prefix) bool {
+	if q.IP.To16() == nil || q.IP.To4() != nil {
+		return false
+	}
+	l := p.Len()
+	if l >= q.Len() {
+		return false
+	}
+	base := ipToIPv6Int(p.IP)
+	mask := ipMaskToIPv6Int(p.Mask)
+	l0, l1 := 64, l-64
+	if l < 64 {
+		l0, l1 = l, 0
+	}
+	fip := ipToIPv6Int(q.IP)
+	lip := q.lastIPv6Int()
+	var fdiff, ldiff ipv6Int
+	fdiff[0], fdiff[1] = (base[0]^fip[0])&mask[0], (base[1]^fip[1])&mask[1]
+	ldiff[0], ldiff[1] = (base[0]^lip[0])&mask[0], (base[1]^lip[1])&mask[1]
+	return leadingZeros64(fdiff[0]) >= l0 && leadingZeros64(fdiff[1]) >= l1 && leadingZeros64(ldiff[0]) >= l0 && leadingZeros64(ldiff[1]) >= l1
+}
+
+// Equal reports whether p and q are equal.
+func (p *Prefix) Equal(q *Prefix) bool {
+	return compareAscending(p, q) == 0
+}
+
+// Exclude returns a list of prefixes that do not contain q.
+func (p *Prefix) Exclude(q *Prefix) []Prefix {
+	if !p.IPNet.Contains(q.IP) {
+		return nil
+	}
+	if p.Equal(q) {
+		return []Prefix{*q}
+	}
+	subsFn := subnetsIPv6
+	if p.IP.To4() != nil {
+		subsFn = subnetsIPv4
+	}
+	var ps []Prefix
+	l, r := subsFn(p, false)
+	for !l.Equal(q) && !r.Equal(q) {
+		if l.IPNet.Contains(q.IP) {
+			ps = append(ps, *r)
+			l, r = subsFn(l, true)
+		} else if r.IPNet.Contains(q.IP) {
+			ps = append(ps, *l)
+			l, r = subsFn(r, true)
+		}
+	}
+	if l.Equal(q) {
+		ps = append(ps, *r)
+	} else if r.Equal(q) {
+		ps = append(ps, *l)
+	}
+	return ps
+}
+
+func subnetsIPv4(p *Prefix, reuse bool) (l *Prefix, r *Prefix) {
+	i := ipToIPv4Int(p.IP) | ipv4Int(1<<uint(IPv4PrefixLen-p.Len()-1))
+	r = i.prefix(p.Len()+1, IPv4PrefixLen)
+	if reuse {
+		l = p
+		binary.BigEndian.PutUint32(l.Mask, mask32(l.Len()+1))
+	} else {
+		l = ipToIPv4Int(p.IP).prefix(p.Len()+1, IPv4PrefixLen)
+	}
+	return
+}
+
+func subnetsIPv6(p *Prefix, reuse bool) (l *Prefix, r *Prefix) {
+	i := ipToIPv6Int(p.IP)
+	id := ipv6Int{0, 1}
+	id.lsh(IPv6PrefixLen - p.Len() - 1)
+	ii := ipv6Int{i[0] | id[0], i[1] | id[1]}
+	r = ii.prefix(p.Len()+1, IPv6PrefixLen)
+	if reuse {
+		l = p
+		var m ipv6Int
+		m.mask(l.Len() + 1)
+		binary.BigEndian.PutUint64(l.Mask[:8], m[0])
+		binary.BigEndian.PutUint64(l.Mask[8:16], m[1])
+	} else {
+		l = i.prefix(p.Len()+1, IPv6PrefixLen)
+	}
+	return
+}
+
+// Hostmask returns a host mask, the inverse mask of p's network mask.
+func (p *Prefix) Hostmask() net.IPMask {
+	return invert(p.Mask)
+}
+
+// Last returns the last IP in the address range of p.
+// It returns the address of p when p contains only one address.
+func (p *Prefix) Last() net.IP {
+	if p.IP.To4() != nil {
+		i := p.lastIPv4Int()
+		return i.ip()
+	}
+	if p.IP.To16() != nil && p.IP.To4() == nil {
+		i := p.lastIPv6Int()
+		return i.ip()
+	}
+	return nil
+}
+
+// Len returns the length of p in bits.
+func (p *Prefix) Len() int {
+	l, _ := p.Mask.Size()
+	return l
+}
+
+// MarshalBinary returns a BGP NLRI binary form of p.
+func (p *Prefix) MarshalBinary() ([]byte, error) {
+	ip := p.IP
+	if p.IP.To4() != nil {
+		ip = p.IP.To4()
+	}
+	var b [1 + net.IPv6len]byte
+	n := p.Len()
+	l := n / 8
+	if n%8 > 0 {
+		l++
+	}
+	b[0] = byte(n)
+	l++
+	copy(b[1:l], ip)
+	return b[:l], nil
+}
+
+// MarshalText returns a UTF-8-encoded text form of p.
+func (p *Prefix) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+// NumNodes returns the number of IP node addresses in p.
+func (p *Prefix) NumNodes() *big.Int {
+	i := new(big.Int).SetBytes(invert(p.Mask))
+	return i.Add(i, big.NewInt(1))
+}
+
+// Overlaps reports whether p overlaps with q.
+func (p *Prefix) Overlaps(q *Prefix) bool {
+	return p.Contains(q) || q.Contains(p) || p.Equal(q)
+}
+
+func (p Prefix) String() string {
+	return p.IPNet.String()
+}
+
+// Subnets returns a list of prefixes that are split from p, into
+// small address blocks by n which represents a number of subnetworks
+// in power of 2 notation.
+func (p *Prefix) Subnets(n int) []Prefix {
+	if 0 > n || n > 17 { // don't bother runtime.makeslice by big numbers
+		return nil
+	}
+	ps := make([]Prefix, 1<<uint(n))
+	if p.IP.To4() != nil {
+		x := ipToIPv4Int(p.IP)
+		off := uint(IPv4PrefixLen - p.Len() - n)
+		for i := range ps {
+			ii := x | ipv4Int(i<<off)
+			ps[i] = *ii.prefix(p.Len()+n, IPv4PrefixLen)
+		}
+		return ps
+	}
+	x := ipToIPv6Int(p.IP)
+	off := IPv6PrefixLen - p.Len() - n
+	for i := range ps {
+		id := ipv6Int{0, uint64(i)}
+		id.lsh(off)
+		ii := ipv6Int{x[0] | id[0], x[1] | id[1]}
+		ps[i] = *ii.prefix(p.Len()+n, IPv6PrefixLen)
+	}
+	return ps
+}
+
+// UnmarshalBinary replaces p with the BGP NLRI binary form b.
+func (p *Prefix) UnmarshalBinary(b []byte) error {
+	if p.IP.To4() != nil {
+		binary.BigEndian.PutUint32(p.Mask, mask32(int(b[0])))
+		copy(p.IP, net.IPv4zero)
+		copy(p.IP.To4(), b[1:])
+	}
+	if p.IP.To16() != nil && p.IP.To4() == nil {
+		var m ipv6Int
+		m.mask(int(b[0]))
+		binary.BigEndian.PutUint64(p.Mask[:8], m[0])
+		binary.BigEndian.PutUint64(p.Mask[8:16], m[1])
+		copy(p.IP, net.IPv6unspecified)
+		copy(p.IP, b[1:])
+	}
+	return nil
+}
+
+// UnmarshalText replaces p with txt.
+func (p *Prefix) UnmarshalText(txt []byte) error {
+	_, n, err := net.ParseCIDR(string(txt))
+	if err != nil {
+		return err
+	}
+	copy(p.IP.To16(), n.IP.To16())
+	copy(p.Mask, n.Mask)
+	return nil
+}
+
+// Aggregate aggregates ps and returns a list of aggregated prefixes.
+func Aggregate(ps []Prefix) []Prefix {
+	ps = newSortedPrefixes(ps, sortDescending, true)
+	switch len(ps) {
+	case 0:
+		return nil
+	case 1:
+		return ps[:1]
+	}
+	bfFn, superFn := branchingFactorIPv6, supernetIPv6
+	if ps[0].IP.To4() != nil {
+		bfFn, superFn = branchingFactorIPv4, supernetIPv4
+	}
+	ps = aggregate(aggregateByBF(ps, bfFn, superFn))
+	sortByAscending(ps)
+	return ps
+}
+
+func aggregateByBF(ps []Prefix, bfFn func([]Prefix) (int, bool), superFn func([]Prefix) *Prefix) []Prefix {
+	var cont bool
+	aggrs := ps[:0]
+	cands := make([]Prefix, 0, len(ps))
+	for len(ps) > 0 {
+		l := ps[0].Len()
+		if l == 0 {
+			aggrs = append(aggrs, ps[0])
+			ps = ps[1:]
+			continue
+		}
+		cands = cands[:0]
+		for i := range ps {
+			if ps[i].Len() != l {
+				break
+			}
+			cands = append(cands, ps[i])
+		}
+		if n, ok := bfFn(cands); !ok {
+			aggrs = append(aggrs, ps[0])
+			ps = ps[1:]
+		} else {
+			aggrs = append(aggrs, *superFn(cands[:n]))
+			ps = ps[n:]
+			cont = true
+		}
+	}
+	sortByDescending(aggrs)
+	if !cont {
+		return aggrs
+	}
+	return aggregateByBF(aggrs, bfFn, superFn)
+}
+
+func aggregate(ps []Prefix) []Prefix {
+	aggrs := ps[:0]
+	for i := range ps {
+		var aggregatable bool
+		for j := len(ps) - 1; j >= 0; j-- {
+			if i == j {
+				continue
+			}
+			if ps[j].Contains(&ps[i]) {
+				aggregatable = true
+				break
+			}
+		}
+		if aggregatable {
+			continue
+		}
+		aggrs = append(aggrs, ps[i])
+	}
+	return aggrs
+}
+
+func branchingFactorIPv4(ps []Prefix) (int, bool) {
+	var lastBF, lastN int
+	base := ipToIPv4Int(ps[0].IP.Mask(ps[0].Mask))
+	mask := ipMaskToIPv4Int(ps[0].Mask)
+	l := ps[0].Len()
+	for bf := 1; bf < IPv4PrefixLen; bf++ {
+		n, nfull := 0, 1<<uint(bf)
+		max := ipv4Int(1 << uint(bf))
+		aggrMask := mask << uint(bf)
+		for pat := ipv4Int(0); pat < max; pat++ {
+			aggr := base&aggrMask | pat<<uint(IPv4PrefixLen-l)
+			for _, p := range ps {
+				i := ipToIPv4Int(p.IP)
+				if aggr == i&mask {
+					n++
+				}
+			}
+		}
+		if n < nfull {
+			break
+		}
+		lastBF = bf
+		lastN = n
+	}
+	n := 1 << uint(lastBF)
+	return n, lastN >= n
+}
+
+func branchingFactorIPv6(ps []Prefix) (int, bool) {
+	var lastBF, lastN int
+	base := ipToIPv6Int(ps[0].IP)
+	mask := ipMaskToIPv6Int(ps[0].Mask)
+	l := ps[0].Len()
+	for bf := 1; bf < IPv6PrefixLen; bf++ {
+		n, nfull := 0, 1<<uint(bf)
+		pat, max := ipv6Int{0, 0}, ipv6Int{0, 1}
+		max.lsh(bf)
+		var aggrMask ipv6Int
+		aggrMask.mask(l - bf)
+		for ; pat.cmp(&max) < 0; pat.incr() {
+			npat := pat
+			npat.lsh(IPv6PrefixLen - l)
+			var aggr ipv6Int
+			aggr[0], aggr[1] = base[0]&aggrMask[0]|npat[0], base[1]&aggrMask[1]|npat[1]
+			for _, p := range ps {
+				i := ipToIPv6Int(p.IP)
+				if aggr[0] == i[0]&mask[0] && aggr[1] == i[1]&mask[1] {
+					n++
+				}
+			}
+		}
+		if n < nfull {
+			break
+		}
+		lastBF = bf
+		lastN = n
+	}
+	n := 1 << uint(lastBF)
+	return n, lastN >= n
+}
+
+// Compare returns an integer comparing two prefixes.
+// The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
+func Compare(a, b *Prefix) int {
+	return compareAscending(a, b)
+}
+
+// NewPrefix returns a new prefix.
+func NewPrefix(n *net.IPNet) *Prefix {
+	n.IP = n.IP.To16()
+	return &Prefix{IPNet: *n}
+}
+
+// Summarize summarizes the address range from first to last and
+// returns a list of prefixes.
+func Summarize(first, last net.IP) []Prefix {
+	if fip := first.To4(); fip != nil {
+		lip := last.To4()
+		if lip == nil {
+			return nil
+		}
+		return summarizeIPv4(fip, lip)
+	}
+	if fip := first.To16(); fip != nil && fip.To4() == nil {
+		lip := last.To16()
+		if lip == nil || last.To4() != nil {
+			return nil
+		}
+		return summarizeIPv6(fip, lip)
+	}
+	return nil
+}
+
+const ipv4IntEOR = ipv4Int(math.MaxUint32)
+
+func summarizeIPv4(fip, lip net.IP) []Prefix {
+	var ps []Prefix
+	fi, li := ipToIPv4Int(fip), ipToIPv4Int(lip)
+	for fi.cmp(li) <= 0 {
+		n := IPv4PrefixLen
+		for n > 0 {
+			m := ipv4Int(mask32(n - 1))
+			l, r := fi&m, fi|ipv4Int(^mask32(n-1))
+			if fi.cmp(l) != 0 || r.cmp(li) > 0 {
+				break
+			}
+			n--
+		}
+		p := fi.prefix(n, IPv4PrefixLen)
+		ps = append(ps, *p)
+		fi = p.lastIPv4Int()
+		if fi == ipv4IntEOR {
+			break
+		}
+		fi++
+	}
+	return ps
+}
+
+var ipv6IntEOR = ipv6Int{math.MaxUint64, math.MaxUint64}
+
+func summarizeIPv6(fip, lip net.IP) []Prefix {
+	var ps []Prefix
+	fi, li := ipToIPv6Int(fip), ipToIPv6Int(lip)
+	for fi.cmp(&li) <= 0 {
+		n := IPv6PrefixLen
+		for n > 0 {
+			var m ipv6Int
+			m.mask(n - 1)
+			l, r := fi, fi
+			l[0], l[1] = l[0]&m[0], l[1]&m[1]
+			r.invmask(n - 1)
+			r[0], r[1] = fi[0]|r[0], fi[1]|r[1]
+			if fi.cmp(&l) != 0 || r.cmp(&li) > 0 {
+				break
+			}
+			n--
+		}
+		p := fi.prefix(n, IPv6PrefixLen)
+		ps = append(ps, *p)
+		fi = p.lastIPv6Int()
+		if fi[0] == ipv6IntEOR[0] && fi[1] == ipv6IntEOR[1] {
+			break
+		}
+		fi.incr()
+	}
+	return ps
+}
+
+// Supernet finds out a shortest common prefix for ps.
+// It returns nil when no suitable prefix is found.
+func Supernet(ps []Prefix) *Prefix {
+	if len(ps) == 0 {
+		return nil
+	}
+	if ps[0].IP.To4() != nil {
+		ps = byAddrFamily(ps).newIPv4Prefixes()
+	}
+	if ps[0].IP.To16() != nil && ps[0].IP.To4() == nil {
+		ps = byAddrFamily(ps).newIPv6Prefixes()
+	}
+	switch len(ps) {
+	case 0:
+		return nil
+	case 1:
+		return &ps[0]
+	}
+	if ps[0].IP.To4() != nil {
+		return supernetIPv4(ps)
+	}
+	if ps[0].IP.To16() != nil && ps[0].IP.To4() == nil {
+		return supernetIPv6(ps)
+	}
+	return nil
+}
+
+func supernetIPv4(ps []Prefix) *Prefix {
+	base := ipToIPv4Int(ps[0].IP.Mask(ps[0].Mask))
+	mask := ipMaskToIPv4Int(ps[0].Mask)
+	n := ps[0].Len()
+	for _, p := range ps[1:] {
+		i := ipToIPv4Int(p.IP)
+		if diff := uint32((base ^ i) & mask); diff != 0 {
+			if l := leadingZeros32(diff); l < n {
+				n = l
+			}
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	return ipToPrefix(ps[0].IP, n, IPv4PrefixLen)
+}
+
+func supernetIPv6(ps []Prefix) *Prefix {
+	base := ipToIPv6Int(ps[0].IP.Mask(ps[0].Mask))
+	mask := ipMaskToIPv6Int(ps[0].Mask)
+	n := ps[0].Len()
+	var diff ipv6Int
+	for _, p := range ps[1:] {
+		i := ipToIPv6Int(p.IP)
+		diff[0], diff[1] = (base[0]^i[0])&mask[0], (base[1]^i[1])&mask[1]
+		if diff[0] != 0 {
+			if l := leadingZeros64(diff[0]); l < n {
+				n = l
+			}
+		} else if diff[1] != 0 {
+			if l := leadingZeros64(diff[1]); 64+l < n {
+				n = 64 + l
+			}
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	return ipToPrefix(ps[0].IP, n, IPv6PrefixLen)
+}
+
+type ipv4Int uint32
+
+func (i ipv4Int) cmp(j ipv4Int) int {
+	if i < j {
+		return -1
+	}
+	if i > j {
+		return +1
+	}
+	return 0
+}
+
+func (i ipv4Int) ip() net.IP {
+	ip := make(net.IP, net.IPv6len)
+	copy(ip, net.IPv4zero)
+	binary.BigEndian.PutUint32(ip.To4(), uint32(i))
+	return ip.To16()
+}
+
+func (i ipv4Int) prefix(l, z int) *Prefix {
+	ip := i.ip()
+	m := net.CIDRMask(l, z)
+	return &Prefix{IPNet: net.IPNet{IP: ip.Mask(m).To16(), Mask: m}}
+}
+
+type ipv6Int [2]uint64
+
+func (i *ipv6Int) cmp(j *ipv6Int) int {
+	if i[0] < j[0] {
+		return -1
+	}
+	if i[0] > j[0] {
+		return +1
+	}
+	if i[1] < j[1] {
+		return -1
+	}
+	if i[1] > j[1] {
+		return +1
+	}
+	return 0
+}
+
+func (i *ipv6Int) decr() {
+	if i[0] == 0 && i[1] == 0 {
+		return
+	}
+	if i[1] > 0 {
+		i[1]--
+	} else {
+		i[0]--
+		i[1] = math.MaxUint64
+	}
+}
+
+func (i *ipv6Int) incr() {
+	if i[1] == math.MaxUint64 {
+		i[0]++
+		i[1] = 0
+	} else {
+		i[1]++
+	}
+}
+
+func (i *ipv6Int) invmask(n int) {
+	if n > 64 {
+		i[0], i[1] = ^mask64(64), ^mask64(n-64)
+	} else {
+		i[0], i[1] = ^mask64(n), mask64(64)
+	}
+}
+
+func (i *ipv6Int) lsh(n int) {
+	i[0] = i[0]<<uint(n) | i[1]>>uint(64-n) | i[1]<<uint(n-64)
+	i[1] = i[1] << uint(n)
+}
+
+func (i *ipv6Int) mask(n int) {
+	if n > 64 {
+		i[0], i[1] = mask64(64), mask64(n-64)
+	} else {
+		i[0], i[1] = mask64(n), 0
+	}
+}
+
+func (i *ipv6Int) ip() net.IP {
+	ip := make(net.IP, net.IPv6len)
+	binary.BigEndian.PutUint64(ip[:8], i[0])
+	binary.BigEndian.PutUint64(ip[8:16], i[1])
+	return ip
+}
+
+func (i *ipv6Int) prefix(l, z int) *Prefix {
+	ip := i.ip()
+	m := net.CIDRMask(l, z)
+	return &Prefix{IPNet: net.IPNet{IP: ip.Mask(m), Mask: m}}
+}
+
+func invert(s []byte) []byte {
+	d := make([]byte, len(s))
+	for i := range s {
+		d[i] = ^s[i]
+	}
+	return d
+}
+
+func ipToIPv4Int(ip net.IP) ipv4Int {
+	return ipv4Int(binary.BigEndian.Uint32(ip.To4()))
+}
+
+func ipToIPv6Int(ip net.IP) ipv6Int {
+	return ipv6Int{binary.BigEndian.Uint64(ip[:8]), binary.BigEndian.Uint64(ip[8:16])}
+}
+
+func ipMaskToIPv4Int(m net.IPMask) ipv4Int {
+	return ipv4Int(binary.BigEndian.Uint32(m))
+}
+
+func ipMaskToIPv6Int(m net.IPMask) ipv6Int {
+	return ipv6Int{binary.BigEndian.Uint64(m[:8]), binary.BigEndian.Uint64(m[8:16])}
+}
+
+func ipToPrefix(s net.IP, l, z int) *Prefix {
+	d := make(net.IP, net.IPv6len)
+	copy(d, s.To16())
+	m := net.CIDRMask(l, z)
+	return &Prefix{IPNet: net.IPNet{IP: d.Mask(m).To16(), Mask: m}}
+}

--- a/vendor/github.com/mikioh/ipaddr/prefix_test.go
+++ b/vendor/github.com/mikioh/ipaddr/prefix_test.go
@@ -1,0 +1,880 @@
+// Copyright 2013 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr_test
+
+import (
+	"bytes"
+	"math/big"
+	"net"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/mikioh/ipaddr"
+)
+
+type byAscending []ipaddr.Prefix
+
+func (ps byAscending) Len() int           { return len(ps) }
+func (ps byAscending) Less(i, j int) bool { return compareAscending(&ps[i], &ps[j]) < 0 }
+func (ps byAscending) Swap(i, j int)      { ps[i], ps[j] = ps[j], ps[i] }
+
+func compareAscending(a, b *ipaddr.Prefix) int {
+	if n := bytes.Compare(a.IP, b.IP); n != 0 {
+		return n
+	}
+	if n := bytes.Compare(a.Mask, b.Mask); n != 0 {
+		return n
+	}
+	return 0
+}
+
+func toPrefix(s string) *ipaddr.Prefix {
+	if s == "" {
+		return nil
+	}
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil
+	}
+	return ipaddr.NewPrefix(n)
+}
+
+func toPrefixes(ss []string) []ipaddr.Prefix {
+	if ss == nil {
+		return nil
+	}
+	var ps []ipaddr.Prefix
+	for _, s := range ss {
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			return nil
+		}
+		ps = append(ps, *ipaddr.NewPrefix(n))
+	}
+	return ps
+}
+
+func TestAggregate(t *testing.T) {
+	for i, tt := range []struct {
+		in, want []string
+	}{
+		// IPv4 prefixes
+		{
+			[]string{
+				"192.0.2.0/25", "192.0.2.128/25",
+			},
+			[]string{
+				"192.0.2.0/24",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.0/26", "192.0.2.64/26", "192.0.2.128/26", "192.0.2.192/26",
+			},
+			[]string{
+				"192.0.2.0/24",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.0/27", "192.0.2.32/27", "192.0.2.64/27", "192.0.2.96/27",
+				"192.0.2.128/27", "192.0.2.160/27", "192.0.2.192/27", "192.0.2.224/27",
+			},
+			[]string{
+				"192.0.2.0/24",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.0/28", "192.0.2.16/28", "192.0.2.32/28", "192.0.2.48/28",
+				"192.0.2.64/28", "192.0.2.80/28", "192.0.2.96/28", "192.0.2.112/28",
+				"192.0.2.128/28", "192.0.2.144/28", "192.0.2.160/28", "192.0.2.176/28",
+				"192.0.2.192/28", "192.0.2.208/28", "192.0.2.224/28", "192.0.2.240/28",
+			},
+			[]string{
+				"192.0.2.0/24",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.0/29", "192.0.2.8/29", "192.0.2.16/29", "192.0.2.24/29",
+				"192.0.2.32/29", "192.0.2.40/29", "192.0.2.48/29", "192.0.2.56/29",
+				"192.0.2.64/29", "192.0.2.72/29", "192.0.2.80/29", "192.0.2.88/29",
+				"192.0.2.96/29", "192.0.2.104/29", "192.0.2.112/29", "192.0.2.120/29",
+				"192.0.2.128/29", "192.0.2.136/29", "192.0.2.144/29", "192.0.2.152/29",
+				"192.0.2.160/29", "192.0.2.168/29", "192.0.2.176/29", "192.0.2.184/29",
+				"192.0.2.192/29", "192.0.2.200/29", "192.0.2.208/29", "192.0.2.216/29",
+				"192.0.2.224/29", "192.0.2.232/29", "192.0.2.240/29", "192.0.2.248/29",
+			},
+			[]string{
+				"192.0.2.0/24",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.0/26", "192.0.2.64/26", "192.0.2.192/26",
+				"192.0.2.128/28", "192.0.2.144/28", "192.0.2.160/28", "192.0.2.176/28",
+			},
+			[]string{
+				"192.0.2.0/24",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.1/32", "192.0.2.1/32",
+			},
+			[]string{
+				"192.0.2.1/32",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.0/25", "192.0.2.128/25",
+				"192.0.2.248/29",
+			},
+			[]string{
+				"192.0.2.0/24",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.0/24",
+				"198.51.100.0/24",
+				"203.0.113.0/24",
+			},
+			[]string{
+				"192.0.2.0/24",
+				"198.51.100.0/24",
+				"203.0.113.0/24",
+			},
+		},
+		{
+			[]string{
+				"192.0.2.0/25",
+				"192.0.2.0/26",
+				"192.0.2.0/27",
+				"192.0.2.0/28",
+				"192.0.2.0/29",
+				"192.0.2.0/30",
+			},
+			[]string{
+				"192.0.2.0/25",
+			},
+		},
+		{
+			[]string{
+				"0.0.0.0/0",
+				"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24",
+				"255.255.255.255/32",
+			},
+			[]string{
+				"0.0.0.0/0",
+			},
+		},
+		{
+			[]string{
+				"0.0.0.0/0", "0.0.0.0/0",
+				"255.255.255.255/32", "255.255.255.255/32",
+			},
+			[]string{
+				"0.0.0.0/0",
+			},
+		},
+		{
+			[]string{
+				"192.168.0.0/25", "192.168.0.128/25",
+				"192.168.1.0/24", "192.168.3.0/24", "192.168.4.0/24",
+				"192.168.5.0/26",
+				"192.168.128.0/22", "192.168.132.0/22",
+				"192.168.128.0/21",
+			},
+			[]string{
+				"192.168.0.0/23",
+				"192.168.3.0/24", "192.168.4.0/24",
+				"192.168.5.0/26",
+				"192.168.128.0/21",
+			},
+		},
+		{
+			[]string{
+				"192.168.0.0/25", "192.168.0.128/25",
+				"192.168.1.0/24", "192.168.3.0/24", "192.168.4.0/24",
+				"192.168.5.0/26",
+			},
+			[]string{
+				"192.168.0.0/23",
+				"192.168.3.0/24", "192.168.4.0/24",
+				"192.168.5.0/26",
+			},
+		},
+
+		// IPv6 prefixes
+		{
+			[]string{
+				"2001:db8::/64", "2001:db8:0:1::/64", "2001:db8:0:2::/64", "2001:db8:0:3::/64",
+				"2001:db8:0:4::/64",
+			},
+			[]string{
+				"2001:db8::/62",
+				"2001:db8:0:4::/64",
+			},
+		},
+		{
+			[]string{
+				"::/0",
+				"2001:db8::/32",
+				"2001:db8::/126",
+				"2001:db8::/127",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128",
+			},
+			[]string{
+				"::/0",
+			},
+		},
+		{
+			[]string{
+				"::/0", "::/0",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128",
+			},
+			[]string{
+				"::/0",
+			},
+		},
+	} {
+		in, orig, want := toPrefixes(tt.in), toPrefixes(tt.in), toPrefixes(tt.want)
+		sort.Sort(byAscending(want))
+		out := ipaddr.Aggregate(in)
+		if !reflect.DeepEqual(out, want) {
+			t.Errorf("#%d: got %v; want %v", i, out, want)
+		}
+		if !reflect.DeepEqual(in, orig) {
+			t.Errorf("#%d: %v is corrupted; want %v", i, in, orig)
+		}
+	}
+
+	ipaddr.Aggregate(nil)
+}
+
+func TestCompare(t *testing.T) {
+	for i, tt := range []struct {
+		in []ipaddr.Prefix
+		n  int
+	}{
+		{toPrefixes([]string{"192.0.2.0/23", "192.0.2.0/24"}), -1},
+		{toPrefixes([]string{"192.0.2.0/24", "192.0.2.0/24"}), 0},
+		{toPrefixes([]string{"192.0.2.0/25", "192.0.2.0/24"}), +1},
+
+		{toPrefixes([]string{"192.0.2.0/24", "198.51.100.0/24"}), -1},
+		{toPrefixes([]string{"198.51.100.0/24", "198.51.100.0/24"}), 0},
+		{toPrefixes([]string{"203.0.113.0/24", "198.51.100.0/24"}), +1},
+
+		{toPrefixes([]string{"2001:db8:1::/47", "2001:db8:1::/48"}), -1},
+		{toPrefixes([]string{"2001:db8:1::/48", "2001:db8:1::/48"}), 0},
+		{toPrefixes([]string{"2001:db8:1::/49", "2001:db8:1::/48"}), +1},
+
+		{toPrefixes([]string{"2001:db8:1::/128", "2001:db8:1::1/128"}), -1},
+		{toPrefixes([]string{"2001:db8:1::1/128", "2001:db8:1::1/128"}), 0},
+		{toPrefixes([]string{"2001:db8:1::2/128", "2001:db8:1::1/128"}), +1},
+
+		{toPrefixes([]string{"192.0.2.1/24", "2001:db8:1::1/64"}), -1},
+		{toPrefixes([]string{"2001:db8:1::1/64", "192.0.2.1/24"}), +1},
+	} {
+		if n := ipaddr.Compare(&tt.in[0], &tt.in[1]); n != tt.n {
+			t.Errorf("#%d: got %v for %v; want %v", i, n, tt.in, tt.n)
+		}
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	for i, tt := range []struct {
+		first, last string
+		want        []string
+	}{
+		// IPv4 prefixes
+		{
+			"192.0.2.0", "192.0.2.255",
+			[]string{
+				"192.0.2.0/24",
+			},
+		},
+		{
+			"1.2.3.4", "5.6.7.8",
+			[]string{
+				"1.2.3.4/30", "1.2.3.8/29", "1.2.3.16/28", "1.2.3.32/27",
+				"1.2.3.64/26", "1.2.3.128/25", "1.2.4.0/22", "1.2.8.0/21",
+				"1.2.16.0/20", "1.2.32.0/19", "1.2.64.0/18", "1.2.128.0/17",
+				"1.3.0.0/16", "1.4.0.0/14", "1.8.0.0/13", "1.16.0.0/12",
+				"1.32.0.0/11", "1.64.0.0/10", "1.128.0.0/9", "2.0.0.0/7",
+				"4.0.0.0/8", "5.0.0.0/14", "5.4.0.0/15", "5.6.0.0/22",
+				"5.6.4.0/23", "5.6.6.0/24", "5.6.7.0/29", "5.6.7.8/32",
+			},
+		},
+		{
+			"255.255.255.255", "255.255.255.255",
+			[]string{
+				"255.255.255.255/32",
+			},
+		},
+		{
+			"0.0.0.0", "255.255.255.255",
+			[]string{
+				"0.0.0.0/0",
+			},
+		},
+		{
+			"0.0.0.1", "255.255.255.254",
+			[]string{
+				"0.0.0.1/32", "0.0.0.2/31", "0.0.0.4/30", "0.0.0.8/29",
+				"0.0.0.16/28", "0.0.0.32/27", "0.0.0.64/26", "0.0.0.128/25",
+				"0.0.1.0/24", "0.0.2.0/23", "0.0.4.0/22", "0.0.8.0/21",
+				"0.0.16.0/20", "0.0.32.0/19", "0.0.64.0/18", "0.0.128.0/17",
+				"0.1.0.0/16", "0.2.0.0/15", "0.4.0.0/14", "0.8.0.0/13",
+				"0.16.0.0/12", "0.32.0.0/11", "0.64.0.0/10", "0.128.0.0/9",
+				"1.0.0.0/8", "2.0.0.0/7", "4.0.0.0/6", "8.0.0.0/5",
+				"16.0.0.0/4", "32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/2",
+				"192.0.0.0/3", "224.0.0.0/4", "240.0.0.0/5", "248.0.0.0/6",
+				"252.0.0.0/7", "254.0.0.0/8", "255.0.0.0/9", "255.128.0.0/10",
+				"255.192.0.0/11", "255.224.0.0/12", "255.240.0.0/13", "255.248.0.0/14",
+				"255.252.0.0/15", "255.254.0.0/16", "255.255.0.0/17", "255.255.128.0/18",
+				"255.255.192.0/19", "255.255.224.0/20", "255.255.240.0/21", "255.255.248.0/22",
+				"255.255.252.0/23", "255.255.254.0/24", "255.255.255.0/25", "255.255.255.128/26",
+				"255.255.255.192/27", "255.255.255.224/28", "255.255.255.240/29", "255.255.255.248/30",
+				"255.255.255.252/31", "255.255.255.254/32",
+			},
+		},
+
+		// IPv6 prefixes
+		{
+			"2001:db8:1::", "2001:db8:2::",
+			[]string{
+				"2001:db8:1::/48",
+				"2001:db8:2::/128",
+			},
+		},
+		{
+			"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			[]string{
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128",
+			},
+		},
+		{
+			"::", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			[]string{
+				"::/0",
+			},
+		},
+		{
+			"::1", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe",
+			[]string{
+				"::1/128", "::2/127", "::4/126", "::8/125",
+				"::10/124", "::20/123", "::40/122", "::80/121",
+				"::100/120", "::200/119", "::400/118", "::800/117",
+				"::1000/116", "::2000/115", "::4000/114", "::8000/113",
+				"::1:0/112", "::2:0/111", "::4:0/110", "::8:0/109",
+				"::10:0/108", "::20:0/107", "::40:0/106", "::80:0/105",
+				"::100:0/104", "::200:0/103", "::400:0/102", "::800:0/101",
+				"::1000:0/100", "::2000:0/99", "::4000:0/98", "::8000:0/97",
+				"::1:0:0/96", "::2:0:0/95", "::4:0:0/94", "::8:0:0/93",
+				"::10:0:0/92", "::20:0:0/91", "::40:0:0/90", "::80:0:0/89",
+				"::100:0:0/88", "::200:0:0/87", "::400:0:0/86", "::800:0:0/85",
+				"::1000:0:0/84", "::2000:0:0/83", "::4000:0:0/82", "::8000:0:0/81",
+				"::1:0:0:0/80", "::2:0:0:0/79", "::4:0:0:0/78", "::8:0:0:0/77",
+				"::10:0:0:0/76", "::20:0:0:0/75", "::40:0:0:0/74", "::80:0:0:0/73",
+				"::100:0:0:0/72", "::200:0:0:0/71", "::400:0:0:0/70", "::800:0:0:0/69",
+				"::1000:0:0:0/68", "::2000:0:0:0/67", "::4000:0:0:0/66", "::8000:0:0:0/65",
+				"0:0:0:1::/64", "0:0:0:2::/63", "0:0:0:4::/62", "0:0:0:8::/61",
+				"0:0:0:10::/60", "0:0:0:20::/59", "0:0:0:40::/58", "0:0:0:80::/57",
+				"0:0:0:100::/56", "0:0:0:200::/55", "0:0:0:400::/54", "0:0:0:800::/53",
+				"0:0:0:1000::/52", "0:0:0:2000::/51", "0:0:0:4000::/50", "0:0:0:8000::/49",
+				"0:0:1::/48", "0:0:2::/47", "0:0:4::/46", "0:0:8::/45",
+				"0:0:10::/44", "0:0:20::/43", "0:0:40::/42", "0:0:80::/41",
+				"0:0:100::/40", "0:0:200::/39", "0:0:400::/38", "0:0:800::/37",
+				"0:0:1000::/36", "0:0:2000::/35", "0:0:4000::/34", "0:0:8000::/33",
+				"0:1::/32", "0:2::/31", "0:4::/30", "0:8::/29",
+				"0:10::/28", "0:20::/27", "0:40::/26", "0:80::/25",
+				"0:100::/24", "0:200::/23", "0:400::/22", "0:800::/21",
+				"0:1000::/20", "0:2000::/19", "0:4000::/18", "0:8000::/17",
+				"1::/16", "2::/15", "4::/14", "8::/13",
+				"10::/12", "20::/11", "40::/10", "80::/9",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff00/121", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff80/122", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffc0/123", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffe0/124",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:fff0/125", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fff8/126", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffc/127", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe/128",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff::/113", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:8000/114", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:c000/115", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:e000/116",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ffff:f000/117", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:f800/118", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fc00/119", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fe00/120",
+				"ffff:ffff:ffff:ffff:ffff:ffff:ff00::/105", "ffff:ffff:ffff:ffff:ffff:ffff:ff80::/106", "ffff:ffff:ffff:ffff:ffff:ffff:ffc0::/107", "ffff:ffff:ffff:ffff:ffff:ffff:ffe0::/108",
+				"ffff:ffff:ffff:ffff:ffff:ffff:fff0::/109", "ffff:ffff:ffff:ffff:ffff:ffff:fff8::/110", "ffff:ffff:ffff:ffff:ffff:ffff:fffc::/111", "ffff:ffff:ffff:ffff:ffff:ffff:fffe::/112",
+				"ffff:ffff:ffff:ffff:ffff:ffff::/97", "ffff:ffff:ffff:ffff:ffff:ffff:8000::/98", "ffff:ffff:ffff:ffff:ffff:ffff:c000::/99", "ffff:ffff:ffff:ffff:ffff:ffff:e000::/100",
+				"ffff:ffff:ffff:ffff:ffff:ffff:f000::/101", "ffff:ffff:ffff:ffff:ffff:ffff:f800::/102", "ffff:ffff:ffff:ffff:ffff:ffff:fc00::/103", "ffff:ffff:ffff:ffff:ffff:ffff:fe00::/104",
+				"ffff:ffff:ffff:ffff:ffff:ff00::/89", "ffff:ffff:ffff:ffff:ffff:ff80::/90", "ffff:ffff:ffff:ffff:ffff:ffc0::/91", "ffff:ffff:ffff:ffff:ffff:ffe0::/92",
+				"ffff:ffff:ffff:ffff:ffff:fff0::/93", "ffff:ffff:ffff:ffff:ffff:fff8::/94", "ffff:ffff:ffff:ffff:ffff:fffc::/95", "ffff:ffff:ffff:ffff:ffff:fffe::/96",
+				"ffff:ffff:ffff:ffff:ffff::/81", "ffff:ffff:ffff:ffff:ffff:8000::/82", "ffff:ffff:ffff:ffff:ffff:c000::/83", "ffff:ffff:ffff:ffff:ffff:e000::/84",
+				"ffff:ffff:ffff:ffff:ffff:f000::/85", "ffff:ffff:ffff:ffff:ffff:f800::/86", "ffff:ffff:ffff:ffff:ffff:fc00::/87", "ffff:ffff:ffff:ffff:ffff:fe00::/88",
+				"ffff:ffff:ffff:ffff:ff00::/73", "ffff:ffff:ffff:ffff:ff80::/74", "ffff:ffff:ffff:ffff:ffc0::/75", "ffff:ffff:ffff:ffff:ffe0::/76",
+				"ffff:ffff:ffff:ffff:fff0::/77", "ffff:ffff:ffff:ffff:fff8::/78", "ffff:ffff:ffff:ffff:fffc::/79", "ffff:ffff:ffff:ffff:fffe::/80",
+				"ffff:ffff:ffff:ffff::/65", "ffff:ffff:ffff:ffff:8000::/66", "ffff:ffff:ffff:ffff:c000::/67", "ffff:ffff:ffff:ffff:e000::/68",
+				"ffff:ffff:ffff:ffff:f000::/69", "ffff:ffff:ffff:ffff:f800::/70", "ffff:ffff:ffff:ffff:fc00::/71", "ffff:ffff:ffff:ffff:fe00::/72",
+				"ffff:ffff:ffff:ff00::/57", "ffff:ffff:ffff:ff80::/58", "ffff:ffff:ffff:ffc0::/59", "ffff:ffff:ffff:ffe0::/60",
+				"ffff:ffff:ffff:fff0::/61", "ffff:ffff:ffff:fff8::/62", "ffff:ffff:ffff:fffc::/63", "ffff:ffff:ffff:fffe::/64",
+				"ffff:ffff:ffff::/49", "ffff:ffff:ffff:8000::/50", "ffff:ffff:ffff:c000::/51", "ffff:ffff:ffff:e000::/52",
+				"ffff:ffff:ffff:f000::/53", "ffff:ffff:ffff:f800::/54", "ffff:ffff:ffff:fc00::/55", "ffff:ffff:ffff:fe00::/56",
+				"ffff:ffff:ff00::/41", "ffff:ffff:ff80::/42", "ffff:ffff:ffc0::/43", "ffff:ffff:ffe0::/44",
+				"ffff:ffff:fff0::/45", "ffff:ffff:fff8::/46", "ffff:ffff:fffc::/47", "ffff:ffff:fffe::/48",
+				"ffff:ffff::/33", "ffff:ffff:8000::/34", "ffff:ffff:c000::/35", "ffff:ffff:e000::/36",
+				"ffff:ffff:f000::/37", "ffff:ffff:f800::/38", "ffff:ffff:fc00::/39", "ffff:ffff:fe00::/40",
+				"ffff:ff00::/25", "ffff:ff80::/26", "ffff:ffc0::/27", "ffff:ffe0::/28",
+				"ffff:fff0::/29", "ffff:fff8::/30", "ffff:fffc::/31", "ffff:fffe::/32",
+				"ffff::/17", "ffff:8000::/18", "ffff:c000::/19", "ffff:e000::/20",
+				"ffff:f000::/21", "ffff:f800::/22", "ffff:fc00::/23", "ffff:fe00::/24",
+				"ff00::/9", "ff80::/10", "ffc0::/11", "ffe0::/12",
+				"fff0::/13", "fff8::/14", "fffc::/15", "fffe::/16",
+				"100::/8", "200::/7", "400::/6", "800::/5",
+				"1000::/4", "2000::/3", "4000::/2", "8000::/2",
+				"c000::/3", "e000::/4", "f000::/5", "f800::/6",
+				"fc00::/7", "fe00::/8",
+			},
+		},
+	} {
+		fip := net.ParseIP(tt.first)
+		if fip == nil {
+			t.Fatalf("non-IP address: %s", tt.first)
+		}
+		lip := net.ParseIP(tt.last)
+		if lip == nil {
+			t.Fatalf("non-IP address: %s", tt.last)
+		}
+		want := toPrefixes(tt.want)
+		sort.Sort(byAscending(want))
+		out := ipaddr.Summarize(fip, lip)
+		if !reflect.DeepEqual(out, want) {
+			t.Errorf("#%d: got %v; want %v", i, out, want)
+		}
+	}
+
+	ipaddr.Summarize(nil, nil)
+}
+
+func TestSupernet(t *testing.T) {
+	for i, tt := range []struct {
+		in   []string
+		want string
+	}{
+		// IPv4 prefixes
+		{
+			[]string{
+				"192.0.2.0/25", "192.0.2.128/25",
+			},
+			"192.0.2.0/24",
+		},
+		{
+			[]string{
+				"192.0.2.0/27", "192.0.2.32/27", "192.0.2.64/27", "192.0.2.96/27",
+				"192.0.2.128/27", "192.0.2.160/27", "192.0.2.192/27", "192.0.2.224/27",
+			},
+			"192.0.2.0/24",
+		},
+		{
+			[]string{
+				"192.0.2.0/28", "192.0.2.16/28", "192.0.2.32/28", "192.0.2.48/28",
+				"192.0.2.64/28", "192.0.2.80/28", "192.0.2.96/28", "192.0.2.112/28",
+				"192.0.2.128/28", "192.0.2.144/28", "192.0.2.160/28", "192.0.2.176/28",
+				"192.0.2.192/28", "192.0.2.208/28", "192.0.2.224/28", "192.0.2.240/28",
+			},
+			"192.0.2.0/24",
+		},
+		{
+			[]string{
+				"10.40.101.1/32", "10.40.102.1/32", "11.40.103.1/32",
+			},
+			"10.0.0.0/7",
+		},
+		{
+			[]string{
+				"192.168.0.0/24", "192.168.1.0/24", "192.168.2.0/24",
+				"192.168.100.0/24", "192.168.200.0/24",
+			},
+			"192.168.0.0/16",
+		},
+
+		// IPv4 prefixes, no supernet
+		{
+			[]string{
+				"128.0.0.0/24",
+				"192.0.0.0/24",
+				"65.0.0.0/24",
+			},
+			"",
+		},
+		{
+			[]string{
+				"0.0.0.0/0",
+				"192.0.0.0/24",
+				"65.0.0.0/24",
+			},
+			"",
+		},
+
+		// IPv6 prefixes
+		{
+			[]string{
+				"2001:db8:1::/32",
+				"2001:db8:2::/39",
+			},
+			"2001:db8::/32",
+		},
+		{
+			[]string{
+				"2013:db8:1::1/64",
+				"192.168.0.1/24",
+				"2013:db8:2::1/64",
+			},
+			"2013:db8::/46",
+		},
+
+		// IPv6 prefixes, no supernet
+		{
+			[]string{
+				"8001:db8:1::/34",
+				"2013:db8:2::/32",
+			},
+			"",
+		},
+		{
+			[]string{
+				"2001:db8::1/64",
+				"192.168.0.1/24",
+				"8001:db8::1/64",
+			},
+			"",
+		},
+
+		// Mixed prefixes
+		{
+			[]string{
+				"192.0.2.0/25",
+				"2001:db8::/64",
+				"192.0.2.128/25",
+			},
+			"192.0.2.0/24",
+		},
+
+		// Mixed prefixes, no supernet
+		{
+			[]string{
+				"0.0.0.0/0",
+				"192.0.2.1/24",
+				"2001:db8::1/64",
+			},
+			"",
+		},
+	} {
+		in, orig := toPrefixes(tt.in), toPrefixes(tt.in)
+		want := toPrefix(tt.want)
+		out := ipaddr.Supernet(in)
+		if !reflect.DeepEqual(out, want) {
+			t.Errorf("#%d: got %v; want %v", i, out, want)
+		}
+		if !reflect.DeepEqual(in, orig) {
+			t.Errorf("#%d: %v is corrupted; want %v", i, in, orig)
+		}
+	}
+
+	ipaddr.Supernet(nil)
+}
+
+func TestPrefixBinaryMarshalerUnmarshaler(t *testing.T) {
+	for i, tt := range []struct {
+		in, tmp string
+		want    []byte
+	}{
+		{
+			"0.0.0.0/0", "1.2.3.4/32",
+			[]byte{0},
+		},
+		{
+			"192.0.0.0/7", "5.6.7.8/32",
+			[]byte{7, 192},
+		},
+		{
+			"192.168.0.0/23", "0.0.0.0/0",
+			[]byte{23, 192, 168, 0},
+		},
+
+		{
+			"::/0", "2001:db8::/8",
+			[]byte{0},
+		},
+		{
+			"2001::/8", "2001:db8::/8",
+			[]byte{8, 0x20},
+		},
+		{
+			"2001:db8:0:cafe:babe::/66", "::/0",
+			[]byte{66, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0xca, 0xfe, 0x80},
+		},
+		{
+			"2001:db8:0:cafe:babe::3/127", "::/0",
+			[]byte{127, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0xca, 0xfe, 0xba, 0xbe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+		},
+	} {
+		p1 := toPrefix(tt.in)
+		out, err := p1.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(out, tt.want) {
+			t.Errorf("#%d: got %v; want %v", i, out, tt.want)
+		}
+		p2 := toPrefix(tt.tmp)
+		if err := p2.UnmarshalBinary(tt.want); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(p2, p1) {
+			t.Errorf("#%d: got %v; want %v", i, p2, p1)
+		}
+	}
+}
+
+func TestPrefixIPNetContains(t *testing.T) {
+	for i, tt := range []struct {
+		in   string
+		ip   net.IP
+		want bool
+	}{
+		{"192.168.0.0/24", net.ParseIP("192.168.0.1"), true},
+
+		{"192.168.0.0/24", net.ParseIP("192.168.1.1"), false},
+
+		{"2001:db8:f001::/48", net.ParseIP("2001:db8:f001::1"), true},
+
+		{"2001:db8:f001::/48", net.ParseIP("2001:db8:f002::1"), false},
+	} {
+		p := toPrefix(tt.in)
+		if out := p.IPNet.Contains(tt.ip); out != tt.want {
+			t.Errorf("#%d: got %v; want %v", i, out, tt.want)
+		}
+	}
+}
+
+func TestPrefixContains(t *testing.T) {
+	for i, tt := range []struct {
+		in []ipaddr.Prefix
+		ok bool
+	}{
+		{toPrefixes([]string{"192.0.2.0/23", "192.0.2.0/24"}), true},
+		{toPrefixes([]string{"192.0.2.0/24", "192.0.2.0/24"}), false},
+		{toPrefixes([]string{"192.0.2.0/25", "192.0.2.0/24"}), false},
+
+		{toPrefixes([]string{"2001:db8:1::/47", "2001:db8:1::/48"}), true},
+		{toPrefixes([]string{"2001:db8:1::/48", "2001:db8:1::/48"}), false},
+		{toPrefixes([]string{"2001:db8:1::/49", "2001:db8:1::/48"}), false},
+
+		{toPrefixes([]string{"2001:db8:1::/127", "2001:db8:1::/128"}), true},
+		{toPrefixes([]string{"2001:db8:1::/127", "2001:db8:1::/127"}), false},
+		{toPrefixes([]string{"2001:db8:1::/128", "2001:db8:1::/127"}), false},
+
+		{toPrefixes([]string{"192.0.2.1/24", "2001:db8:1::1/64"}), false},
+		{toPrefixes([]string{"2001:db8:1::1/64", "192.0.2.1/24"}), false},
+	} {
+		if ok := tt.in[0].Contains(&tt.in[1]); ok != tt.ok {
+			t.Errorf("#%d: got %v; want %v", i, ok, tt.ok)
+		}
+	}
+}
+
+func TestPrefixExclude(t *testing.T) {
+	for i, tt := range []struct {
+		in, excl string
+	}{
+		{"192.0.0.0/16", "192.0.2.0/24"},
+		{"192.0.2.0/24", "192.0.2.0/32"},
+
+		{"2001:db8:f001::/48", "2001:db8:f001:f002::/56"},
+		{"2001:db8:f001:f002::/64", "2001:db8:f001:f002::cafe/128"},
+	} {
+		p, excl := toPrefix(tt.in), toPrefix(tt.excl)
+		ps := p.Exclude(excl)
+		if len(ps) != excl.Len()-p.Len() {
+			for _, p := range ps {
+				t.Logf("subnet: %v", p)
+			}
+			t.Errorf("#%d: got %v; want %v", i, len(ps), excl.Len()-p.Len())
+		}
+		diff, sum := big.NewInt(0), big.NewInt(0)
+		diff.Sub(p.NumNodes(), excl.NumNodes())
+		for _, p := range ps {
+			sum.Add(sum, p.NumNodes())
+		}
+		if diff.String() != sum.String() {
+			for _, p := range ps {
+				t.Logf("subnet: %v", p)
+			}
+			t.Errorf("#%d: got %v; want %v", i, sum.String(), diff.String())
+		}
+	}
+}
+
+func TestPrefixLast(t *testing.T) {
+	for i, tt := range []struct {
+		in      string
+		l       int
+		ip, lip net.IP
+	}{
+		{"192.0.0.0/16", 16, net.ParseIP("192.0.0.0"), net.ParseIP("192.0.255.255")},
+		{"192.0.2.255/24", 24, net.ParseIP("192.0.2.0"), net.ParseIP("192.0.2.255")},
+
+		{"2001:db8:0:0:1:2:3:cafe/64", 64, net.ParseIP("2001:db8::"), net.ParseIP("2001:db8::ffff:ffff:ffff:ffff")},
+		{"2001:db8::ca7e/121", 121, net.ParseIP("2001:db8::ca00"), net.ParseIP("2001:db8::ca7f")},
+	} {
+		p := toPrefix(tt.in)
+		if !p.IP.Equal(tt.ip) {
+			t.Errorf("#%d: got %v; want %v", i, p.IP, tt.ip)
+		}
+		if p.Len() != tt.l {
+			t.Errorf("#%d: got %v; want %v", i, p.Len(), tt.l)
+		}
+		if !p.Last().Equal(tt.lip) {
+			t.Errorf("#%d: got %v; want %v", i, p.Last(), tt.lip)
+		}
+	}
+}
+
+func TestPrefixMask(t *testing.T) {
+	inverse := func(s net.IPMask) net.IPMask {
+		d := make(net.IPMask, len(s))
+		for i := range s {
+			d[i] = ^s[i]
+		}
+		return d
+	}
+
+	for i, tt := range []struct {
+		in string
+		m  net.IPMask
+	}{
+		{"192.0.2.255/16", net.CIDRMask(16, ipaddr.IPv4PrefixLen)},
+
+		{"2001:db8::/64", net.CIDRMask(64, ipaddr.IPv6PrefixLen)},
+	} {
+		p := toPrefix(tt.in)
+		if bytes.Compare(p.Mask, tt.m) != 0 {
+			t.Errorf("#%d: got %v; want %v", i, p.Mask, tt.m)
+		}
+		m := inverse(tt.m)
+		if bytes.Compare(p.Hostmask(), m) != 0 {
+			t.Errorf("#%d: got %v; want %v", i, p.Hostmask(), m)
+		}
+	}
+}
+
+func TestPrefixNumNodes(t *testing.T) {
+	for i, tt := range []struct {
+		in string
+		n  *big.Int
+	}{
+		{"192.0.2.0/0", big.NewInt(1 << 32)},
+		{"192.0.2.0/16", big.NewInt(1 << 16)},
+		{"192.0.2.0/32", big.NewInt(1)},
+
+		{"2001:db8::/0", new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil)},
+		{"2001:db8::/32", new(big.Int).Exp(big.NewInt(2), big.NewInt(96), nil)},
+		{"2001:db8::/64", new(big.Int).Exp(big.NewInt(2), big.NewInt(64), nil)},
+		{"2001:db8::/96", new(big.Int).Exp(big.NewInt(2), big.NewInt(32), nil)},
+		{"2001:db8::/128", new(big.Int).Exp(big.NewInt(2), big.NewInt(0), nil)},
+	} {
+		p := toPrefix(tt.in)
+		if p.NumNodes().String() != tt.n.String() {
+			t.Errorf("#%d: got %v; want %v", i, p.NumNodes().String(), tt.n.String())
+		}
+	}
+}
+
+func TestPrefixOverlaps(t *testing.T) {
+	for i, tt := range []struct {
+		in     string
+		others []string
+		want   bool
+	}{
+		{"192.0.2.0/24", []string{"192.0.2.0/25", "192.0.2.64/26"}, true},
+
+		{"192.0.2.0/24", []string{"198.51.100.0/25", "198.51.100.128/25"}, false},
+
+		{"2001:db8:f001::/48", []string{"2001:db8:f001:4000::/49", "2001:db8:f001:8000::/49"}, true},
+
+		{"2001:db8:f001::/48", []string{"2001:db8:f002:4000::/49", "2001:db8:f002:8000::/49"}, false},
+	} {
+		p1 := toPrefix(tt.in)
+		others := toPrefixes(tt.others)
+		p2 := ipaddr.Supernet(others)
+		if out := p1.Overlaps(p2); out != tt.want {
+			t.Errorf("#%d: got %v; want %v", i, out, tt.want)
+		}
+		if out := p2.Overlaps(p1); out != tt.want {
+			t.Errorf("#%d: got %v; want %v", i, out, tt.want)
+		}
+	}
+}
+
+func TestPrefixSubnets(t *testing.T) {
+	for i, tt := range []struct {
+		in string
+		l  int
+		n  int
+	}{
+		{"192.0.2.128/25", 25, 4},
+		{"192.0.2.0/29", 29, 2},
+
+		{"2001:db8::/65", 65, 8},
+		{"2001:db8::/51", 51, 9},
+		{"2001:db8::/32", 32, 1},
+		{"2001:db8::/13", 13, 7},
+		{"2001:db8::/64", 64, 3},
+		{"2001:db8::/61", 61, 5},
+		{"2001:db8::80/121", 121, 6},
+	} {
+		p := toPrefix(tt.in)
+		ps := p.Subnets(tt.n)
+		if len(ps) != 1<<uint(tt.n) {
+			t.Errorf("#%d: got %v; want %v", i, len(ps), 1<<uint(tt.n))
+		}
+		for _, p := range ps {
+			if p.Len() != tt.l+tt.n {
+				t.Errorf("#%d: got %v; want %v", i, p.Len(), tt.l+tt.n)
+			}
+		}
+		if super := ipaddr.Supernet(ps); super == nil {
+			for _, p := range ps {
+				t.Logf("subnet: %v", p)
+			}
+			t.Errorf("#%d: got %v; want %v", i, super, p)
+		}
+	}
+}
+
+func TestPrefixTextMarshalerUnmarshaler(t *testing.T) {
+	for i, tt := range []struct {
+		in, tmp string
+		out     []byte
+	}{
+		{"192.0.2.0/24", "0.0.0.0/0", []byte("192.0.2.0/24")},
+
+		{"2001:db8::cafe/127", "::/0", []byte("2001:db8::cafe/127")},
+	} {
+		p1 := toPrefix(tt.in)
+		out, err := p1.MarshalText()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(out, tt.out) {
+			t.Errorf("#%d: got %v; want %v", i, out, tt.out)
+		}
+		p2 := toPrefix(tt.tmp)
+		if err := p2.UnmarshalText(tt.out); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(p2, p1) {
+			t.Errorf("#%d: got %v; want %v", i, p2, p1)
+		}
+	}
+}

--- a/vendor/github.com/mikioh/ipaddr/sort.go
+++ b/vendor/github.com/mikioh/ipaddr/sort.go
@@ -1,0 +1,100 @@
+// Copyright 2013 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+package ipaddr
+
+import (
+	"bytes"
+	"net"
+)
+
+type byAddrFamily []Prefix
+
+func (ps byAddrFamily) newIPv4Prefixes() []Prefix {
+	nps := make([]Prefix, 0, len(ps))
+	for _, p := range ps {
+		if p.IP.To4() != nil {
+			np := clonePrefix(&p)
+			nps = append(nps, *np)
+		}
+	}
+	return nps
+}
+
+func (ps byAddrFamily) newIPv6Prefixes() []Prefix {
+	nps := make([]Prefix, 0, len(ps))
+	for _, p := range ps {
+		if p.IP.To16() != nil && p.IP.To4() == nil {
+			np := clonePrefix(&p)
+			nps = append(nps, *np)
+		}
+	}
+	return nps
+}
+
+func compareAscending(a, b *Prefix) int {
+	if n := bytes.Compare(a.IP, b.IP); n != 0 {
+		return n
+	}
+	if n := bytes.Compare(a.Mask, b.Mask); n != 0 {
+		return n
+	}
+	return 0
+}
+
+type sortDir int
+
+const (
+	sortAscending sortDir = iota
+	sortDescending
+)
+
+func newSortedPrefixes(ps []Prefix, dir sortDir, strict bool) []Prefix {
+	if len(ps) == 0 {
+		return nil
+	}
+	if strict {
+		if ps[0].IP.To4() != nil {
+			ps = byAddrFamily(ps).newIPv4Prefixes()
+		}
+		if ps[0].IP.To16() != nil && ps[0].IP.To4() == nil {
+			ps = byAddrFamily(ps).newIPv6Prefixes()
+		}
+		if dir == sortAscending {
+			sortByAscending(ps)
+		} else {
+			sortByDescending(ps)
+		}
+	} else {
+		nps := make([]Prefix, 0, len(ps))
+		for i := range ps {
+			np := clonePrefix(&ps[i])
+			nps = append(nps, *np)
+		}
+		if dir == sortAscending {
+			sortByAscending(nps)
+		} else {
+			sortByDescending(nps)
+		}
+		ps = nps
+	}
+	nps := ps[:0]
+	var p *Prefix
+	for i := range ps {
+		if p == nil {
+			nps = append(nps, ps[i])
+		} else if !p.Equal(&ps[i]) {
+			nps = append(nps, ps[i])
+		}
+		p = &ps[i]
+	}
+	return nps
+}
+
+func clonePrefix(s *Prefix) *Prefix {
+	d := &Prefix{IPNet: net.IPNet{IP: make(net.IP, net.IPv6len), Mask: make(net.IPMask, len(s.Mask))}}
+	copy(d.IP, s.IP.To16())
+	copy(d.Mask, s.Mask)
+	return d
+}

--- a/vendor/github.com/mikioh/ipaddr/sort_go1_7.go
+++ b/vendor/github.com/mikioh/ipaddr/sort_go1_7.go
@@ -1,0 +1,42 @@
+// Copyright 2013 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+// +build !go1.8
+
+package ipaddr
+
+import (
+	"bytes"
+	"sort"
+)
+
+type byAscending []Prefix
+
+func (ps byAscending) Len() int           { return len(ps) }
+func (ps byAscending) Less(i, j int) bool { return compareAscending(&ps[i], &ps[j]) < 0 }
+func (ps byAscending) Swap(i, j int)      { ps[i], ps[j] = ps[j], ps[i] }
+
+func sortByAscending(ps []Prefix) {
+	sort.Sort(byAscending(ps))
+}
+
+type byDescending []Prefix
+
+func (ps byDescending) Len() int           { return len(ps) }
+func (ps byDescending) Less(i, j int) bool { return compareDescending(&ps[i], &ps[j]) >= 0 }
+func (ps byDescending) Swap(i, j int)      { ps[i], ps[j] = ps[j], ps[i] }
+
+func compareDescending(a, b *Prefix) int {
+	if n := bytes.Compare(a.Mask, b.Mask); n != 0 {
+		return n
+	}
+	if n := bytes.Compare(a.IP, b.IP); n != 0 {
+		return n
+	}
+	return 0
+}
+
+func sortByDescending(ps []Prefix) {
+	sort.Sort(byDescending(ps))
+}

--- a/vendor/github.com/mikioh/ipaddr/sort_go1_8.go
+++ b/vendor/github.com/mikioh/ipaddr/sort_go1_8.go
@@ -1,0 +1,36 @@
+// Copyright 2017 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.
+
+// +build go1.8
+
+package ipaddr
+
+import (
+	"bytes"
+	"sort"
+)
+
+func sortByAscending(ps []Prefix) {
+	sort.Slice(ps, func(i, j int) bool {
+		if n := bytes.Compare(ps[i].IP, ps[j].IP); n != 0 {
+			return n < 0
+		}
+		if n := bytes.Compare(ps[i].Mask, ps[j].Mask); n != 0 {
+			return n < 0
+		}
+		return false
+	})
+}
+
+func sortByDescending(ps []Prefix) {
+	sort.Slice(ps, func(i, j int) bool {
+		if n := bytes.Compare(ps[i].Mask, ps[j].Mask); n != 0 {
+			return n >= 0
+		}
+		if n := bytes.Compare(ps[i].IP, ps[i].IP); n != 0 {
+			return n >= 0
+		}
+		return false
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:

Vendors in an IP address prefix and address walking package to replace the existing IPv4 only implementations.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes # n/a



**Special notes for your reviewer**:

I figure this will be easier than making some of the current allocator functions also deal with IPv6.