### PR TITLE
internal/allocator: replace address traversal with ipaddr package

### DIFF
--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -413,31 +413,6 @@ func TestARPForbidden(t *testing.T) {
 
 }
 
-func TestNextIP(t *testing.T) {
-	tests := []struct {
-		in, out string
-	}{
-		{"1.2.3.4", "1.2.3.5"},
-		{"0.0.0.0", "0.0.0.1"},
-		{"1.2.3.255", "1.2.4.0"},
-		{"1.2.255.255", "1.3.0.0"},
-		{"1.255.255.255", "2.0.0.0"},
-		{"255.255.255.255", "0.0.0.0"},
-		{"::1", "::2"},
-	}
-
-	for i, test := range tests {
-		in, out := net.ParseIP(test.in), net.ParseIP(test.out)
-		if in == nil || out == nil {
-			t.Fatalf("Invalid test case #%d, IPs don't parse", i+1)
-		}
-		got := nextIP(in)
-		if !got.Equal(out) {
-			t.Errorf("nextIP(%q), got %q, want %q", in, got, out)
-		}
-	}
-}
-
 func TestConfigReload(t *testing.T) {
 	alloc := New()
 	if err := alloc.SetPools(map[string]*config.Pool{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:

Makes use of `ipaddr`'s address traversal functions, which can also deal with IPv6 addresses.  IPv4 addresses are still assumed in this PR because IPv6 addresses will need to be threaded through the code later.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes # n/a



**Special notes for your reviewer**:

n/a