### PR TITLE
speaker: allow speaker to have an IPv6 address

### DIFF
--- a/internal/arp/arp.go
+++ b/internal/arp/arp.go
@@ -2,7 +2,6 @@ package arp
 
 import (
 	"bytes"
-	"fmt"
 	"net"
 	"sync"
 
@@ -26,11 +25,9 @@ type Announce struct {
 }
 
 // New returns an initialized Announce.
-func New(ip net.IP) (*Announce, error) {
-	ifi, err := iface.ByIP(ip)
-	if err != nil {
-		return nil, fmt.Errorf("arp: can't find interface for %s: %s", ip, err)
-	}
+func New(ifi *net.Interface) (*Announce, error) {
+	glog.Infof("creating ARP announcer on interface %q", ifi.Name)
+
 	client, err := arp.Dial(ifi)
 	if err != nil {
 		return nil, err

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -170,7 +170,11 @@ func TestBGPSpeaker(t *testing.T) {
 		gotAds: map[string][]*bgp.Advertisement{},
 	}
 	newBGP = b.New
-	c, err := newController(net.ParseIP("1.2.3.4"), "pandora", true)
+	c, err := newController(controllerConfig{
+		NodeIP:     net.ParseIP("1.2.3.4"),
+		MyNode:     "pandora",
+		DisableARP: true,
+	})
 	if err != nil {
 		t.Fatalf("creating controller: %s", err)
 	}
@@ -708,7 +712,11 @@ func TestNodeSelectors(t *testing.T) {
 		gotAds: map[string][]*bgp.Advertisement{},
 	}
 	newBGP = b.New
-	c, err := newController(net.ParseIP("1.2.3.4"), "pandora", true)
+	c, err := newController(controllerConfig{
+		NodeIP:     net.ParseIP("1.2.3.4"),
+		MyNode:     "pandora",
+		DisableARP: true,
+	})
 	if err != nil {
 		t.Fatalf("creating controller: %s", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:

First pass at threading a bit of IPv6 goodness through the speaker.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Updates #7.



**Special notes for your reviewer**:

I tried to make things a bit more extensible and general, and got a head start on plumbing a bit of IPv6 addressing through.  It probably needs more work though.