### PR TITLE
speaker: plumb in NDP speaker

### DIFF
--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -174,6 +174,7 @@ func TestBGPSpeaker(t *testing.T) {
 		NodeIP:     net.ParseIP("1.2.3.4"),
 		MyNode:     "pandora",
 		DisableARP: true,
+		DisableNDP: true,
 	})
 	if err != nil {
 		t.Fatalf("creating controller: %s", err)
@@ -716,6 +717,7 @@ func TestNodeSelectors(t *testing.T) {
 		NodeIP:     net.ParseIP("1.2.3.4"),
 		MyNode:     "pandora",
 		DisableARP: true,
+		DisableNDP: true,
 	})
 	if err != nil {
 		t.Fatalf("creating controller: %s", err)

--- a/speaker/ndp_controller.go
+++ b/speaker/ndp_controller.go
@@ -1,0 +1,54 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net"
+
+	"go.universe.tf/metallb/internal/config"
+	"go.universe.tf/metallb/internal/ndp"
+	"k8s.io/api/core/v1"
+)
+
+// TODO(mdlayher): this is an almost exact copy of the ARP controller. Deduplicate.
+
+type ndpController struct {
+	announcer *ndp.Announce
+}
+
+func (c *ndpController) SetConfig(*config.Config) error {
+	return nil
+}
+
+func (c *ndpController) SetBalancer(name string, lbIP net.IP, pool *config.Pool) error {
+	c.announcer.SetBalancer(name, lbIP)
+	return nil
+}
+
+func (c *ndpController) DeleteBalancer(name, reason string) error {
+	if !c.announcer.AnnounceName(name) {
+		return nil
+	}
+	c.announcer.DeleteBalancer(name)
+	return nil
+}
+
+func (c *ndpController) SetLeader(isLeader bool) {
+	c.announcer.SetLeader(isLeader)
+}
+
+func (c *ndpController) SetNode(*v1.Node) error {
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:

Hooks up the NDP speaker to the `speaker` binary.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Updates #83, but may be very close to fixing it too.



**Special notes for your reviewer**:

Will be rebased after #154 and #155 are merged.  I split them up for easier review.

This _might_ actually work but I can't tell at the moment because I haven't found a network addon that can do both IPv6 and runs on ARM.  But I could see TCP traffic (HTTP) being pulled at my speaker's advertised IPv6 address, so assuming Kubernetes can do its thing, I think I've about got it!