### PR TITLE
WIP: Remove metallb-system namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,13 +84,13 @@ push-manifests:
 push: gen-image-targets
 	+make -f $(MK_IMAGE_TARGETS) $(foreach bin,$(BINARIES),$(bin)/$(ARCH))
 ifeq ($(findstring localhost,$(REGISTRY)),localhost)
-	kubectl set image -n metallb-system deploy/controller controller=$(shell kubectl get svc -n kube-system registry -o go-template='{{.spec.clusterIP}}'):80/controller:$(TAG)-$(ARCH)
-	kubectl set image -n metallb-system ds/speaker speaker=$(shell kubectl get svc -n kube-system registry -o go-template='{{.spec.clusterIP}}'):80/speaker:$(TAG)-$(ARCH)
-	kubectl set image -n metallb-system deploy/test-bgp-router test-bgp-router=$(shell kubectl get svc -n kube-system registry -o go-template='{{.spec.clusterIP}}'):80/test-bgp-router:$(TAG)-$(ARCH)
+	kubectl set image deploy/controller controller=$(shell kubectl get svc -n kube-system registry -o go-template='{{.spec.clusterIP}}'):80/controller:$(TAG)-$(ARCH)
+	kubectl set image ds/speaker speaker=$(shell kubectl get svc -n kube-system registry -o go-template='{{.spec.clusterIP}}'):80/speaker:$(TAG)-$(ARCH)
+	kubectl set image deploy/test-bgp-router test-bgp-router=$(shell kubectl get svc -n kube-system registry -o go-template='{{.spec.clusterIP}}'):80/test-bgp-router:$(TAG)-$(ARCH)
 else
-	kubectl set image -n metallb-system deploy/controller controller=$(REGISTRY)/controller:$(TAG)-$(ARCH)
-	kubectl set image -n metallb-system ds/speaker speaker=$(REGISTRY)/speaker:$(TAG)-$(ARCH)
-	kubectl set image -n metallb-system deploy/test-bgp-router test-bgp-router=$(REGISTRY)/test-bgp-router:$(TAG)-$(ARCH)
+	kubectl set image deploy/controller controller=$(REGISTRY)/controller:$(TAG)-$(ARCH)
+	kubectl set image ds/speaker speaker=$(REGISTRY)/speaker:$(TAG)-$(ARCH)
+	kubectl set image deploy/test-bgp-router test-bgp-router=$(REGISTRY)/test-bgp-router:$(TAG)-$(ARCH)
 endif
 
 ################################

--- a/controller/main.go
+++ b/controller/main.go
@@ -125,7 +125,6 @@ func main() {
 	kubeconfig := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	master := flag.String("master", "", "master url")
 	port := flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
-	configNS := flag.String("config-ns", "metallb-system", "Kubernetes namespace containing MetalLB's configuration")
 	config := flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
 	flag.Parse()
 
@@ -140,7 +139,7 @@ func main() {
 		glog.Fatalf("Error getting k8s client: %s", err)
 	}
 	client.HandleService(c.SetBalancer)
-	client.HandleConfig(*configNS, *config, c.SetConfig)
+	client.HandleConfig(*config, c.SetConfig)
 	client.HandleSynced(c.MarkSynced)
 
 	c.client = client

--- a/internal/k8s/leader.go
+++ b/internal/k8s/leader.go
@@ -13,8 +13,9 @@ func (c *Client) HandleLeadership(nodeName string, handler func(bool)) {
 	if c.elector != nil {
 		panic("HandleLeadership called twice")
 	}
+
 	conf := resourcelock.ResourceLockConfig{Identity: nodeName, EventRecorder: c.events}
-	lock, err := resourcelock.New(resourcelock.EndpointsResourceLock, "metallb-system", "metallb-speaker", c.client.CoreV1(), conf)
+	lock, err := resourcelock.New(resourcelock.EndpointsResourceLock, c.namespace, "metallb-speaker", c.client.CoreV1(), conf)
 	if err != nil {
 		panic(err)
 	}

--- a/manifests/example-arp-config.yaml
+++ b/manifests/example-arp-config.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: metallb-system
   name: config
 data:
   config: |

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: metallb-system
   name: config
 data:
   config: |

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -1,17 +1,10 @@
 ---
-# Source: metallb/templates/namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: metallb-system
-
----
 # Source: metallb/templates/rbac.yaml
 # Roles
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metallb-system:controller
+  name: metallb:controller
 rules:
 - apiGroups: [""]
   resources: ["services"]
@@ -26,7 +19,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metallb-system:speaker
+  name: metallb:speaker
 rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
@@ -35,7 +28,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: metallb-system
   name: leader-election
 rules:
 - apiGroups: [""]
@@ -49,7 +41,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: metallb-system
   name: config-watcher
 rules:
 - apiGroups: [""]
@@ -64,13 +55,11 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: metallb-system
   name: controller
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: metallb-system
   name: speaker
 ---
 
@@ -78,33 +67,32 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metallb-system:controller
+  name: metallb:controller
 subjects:
 - kind: ServiceAccount
-  namespace: metallb-system
   name: controller
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metallb-system:controller
+  name: metallb:controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metallb-system:speaker
+  name: metallb:speaker
 subjects:
 - kind: ServiceAccount
-  namespace: metallb-system
   name: speaker
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metallb-system:speaker
+  name: metallb:speaker
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: metallb-system
   name: config-watcher
 subjects:
 - kind: ServiceAccount
@@ -119,7 +107,6 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: metallb-system
   name: leader-election
 subjects:
 - kind: ServiceAccount
@@ -133,7 +120,6 @@ roleRef:
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  namespace: metallb-system
   name: controller
   labels:
     app: metallb
@@ -184,7 +170,6 @@ spec:
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
-  namespace: metallb-system
   name: speaker
   labels:
     app: metallb

--- a/manifests/test-bgp-router.yaml
+++ b/manifests/test-bgp-router.yaml
@@ -1,13 +1,7 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: metallb-system
-
 ---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  namespace: metallb-system
   name: test-bgp-router
 spec:
   revisionHistoryLimit: 3
@@ -46,7 +40,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: metallb-system
   name: test-bgp-router-bird
 spec:
   ports:
@@ -62,7 +55,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: metallb-system
   name: test-bgp-router-quagga
 spec:
   ports:
@@ -78,7 +70,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: metallb-system
   name: test-bgp-router-ui
 spec:
   ports:

--- a/manifests/tutorial-1.yaml
+++ b/manifests/tutorial-1.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: metallb-system
   name: config
 data:
   config: |

--- a/manifests/tutorial-3.yaml
+++ b/manifests/tutorial-3.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: metallb-system
   name: config
 data:
   config: |

--- a/manifests/tutorial-4.yaml
+++ b/manifests/tutorial-4.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: metallb-system
   name: config
 data:
   config: |

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -55,7 +55,6 @@ func main() {
 		myIPstr    = flag.String("node-ip", "", "IP address of this Kubernetes node")
 		myNode     = flag.String("node-name", "", "name of this Kubernetes node")
 		port       = flag.Int("port", 80, "HTTP listening port")
-		configNS   = flag.String("config-ns", "metallb-system", "Kubernetes namespace containing MetalLB's configuration")
 		config     = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
 	)
 	flag.Parse()
@@ -101,7 +100,7 @@ func main() {
 		glog.Fatalf("Error getting k8s client: %s", err)
 	}
 	client.HandleServiceAndEndpoints(ctrl.SetBalancer)
-	client.HandleConfig(*configNS, *config, ctrl.SetConfig)
+	client.HandleConfig(*config, ctrl.SetConfig)
 	client.HandleLeadership(*myNode, ctrl.SetLeader)
 	client.HandleNode(*myNode, ctrl.SetNode)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a first draft of how to remove the hardcoded  `metallb-system` namespace and make metallb namespace-agnostic.

* Adds a function `InClusterNamespace` to `internal/k8s/` to detect the namespace the pod is currently running in
* Uses above function to determine the namespace for config and leader election. 
* Removes the `--config-ns` parameter. 
* Updates the manifests in `manifests/` to use the default namespace. This is just as POC we might just keep the `metallb-namespace` in there - it does not matter with the changes anymore. I did not update the helm chart because it will probably be maintained in kubernetes/charts in the near future.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #193



**Special notes for your reviewer**:
~~Please elaborate on why the `--config-ns` parameter is necessary. Should the metallb controller be able to run outside of cluster? I can not think of any other scenarios. If this is not the case, it should probably be removed and default to namespace metallb is running in.~~
