### PR TITLE
internal/config: remove deprecated field names.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,11 +61,9 @@ type addressPool struct {
 	Protocol          Proto
 	Name              string
 	Addresses         []string
-	CIDR              []string           // TODO: remove in 0.6.0
 	AvoidBuggyIPs     bool               `yaml:"avoid-buggy-ips"`
 	AutoAssign        *bool              `yaml:"auto-assign"`
 	BGPAdvertisements []bgpAdvertisement `yaml:"bgp-advertisements"`
-	ARPNetwork        string             `yaml:"arp-network"` // TODO: remove in 0.6.0
 }
 
 type bgpAdvertisement struct {
@@ -312,7 +310,6 @@ func parseAddressPool(p addressPool, bgpCommunities map[string]uint32) (*Pool, e
 		ret.AutoAssign = *p.AutoAssign
 	}
 
-	p.Addresses = append(p.Addresses, p.CIDR...)
 	if len(p.Addresses) == 0 {
 		return nil, errors.New("pool has no prefixes defined")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,7 +85,6 @@ address-pools:
   protocol: layer2
   addresses:
   - 40.0.0.0/25
-  cidr:
   - 40.0.0.150-40.0.0.200
 - name: pool4
   protocol: arp


### PR DESCRIPTION
As foretold in #198.

Fixes #198