### PR TITLE
Adding patch permission to controller

### DIFF
--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -21,7 +21,7 @@ rules:
   verbs: ["update"]
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"]
+  verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Controller needs `patch` permission for events. Adding it to deployment yaml.
 
Closes #213 