### PR TITLE
Reimport a copy of the Helm chart.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,14 @@ jobs:
       - image: circleci/golang:1.9
     steps:
       - checkout
-      - run: make ci-prepare
-      - run: make ci-build
-      - run: make ci-test
-      - run: make ci-lint
+      - run: make ci
   test-1.10:
     working_directory: /go/src/go.universe.tf/metallb
     docker:
       - image: circleci/golang:1.10
     steps:
       - checkout
-      - run: make ci-prepare
-      - run: make ci-build
-      - run: make ci-test
-      - run: make ci-lint
+      - run: make ci
   deploy-controller:
     working_directory: /go/src/go.universe.tf/metallb
     docker:

--- a/.circleci/config.yml.tmpl
+++ b/.circleci/config.yml.tmpl
@@ -9,10 +9,7 @@ jobs:
       - image: circleci/golang:{{.}}
     steps:
       - checkout
-      - run: make ci-prepare
-      - run: make ci-build
-      - run: make ci-test
-      - run: make ci-lint
+      - run: make ci
 {{- end }}
 {{- range $bin := $.Binary }}
   deploy-{{$bin}}:

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ else
 	PREV_VERSION=v$(MAJOR).$(MINOR).$(shell expr $(PATCH) - 1)
 endif
 
+.PHONY: release
 release:
 ifeq ($(VERSION),)
 	$(error VERSION is required)

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ ci-config:
 
 .PHONY: ci-prepare
 ci-prepare:
+	curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
 	$(GOCMD) get github.com/Masterminds/glide
 	$(GOCMD) get github.com/golang/lint/golint
 	$(GOCMD) get github.com/estesp/manifest-tool

--- a/Makefile
+++ b/Makefile
@@ -227,9 +227,9 @@ endif
 
 	perl -pi -e 's#image: metallb/(.*):.*#image: metallb/$$1:v$(VERSION)#g' manifests/*.yaml
 
-	perl -pi -e 's/appVersion: .*/appVersion: $(VERSION)/g' helm/metallb/Chart.yaml
-	perl -pi -e 's/tag: .*/tag: v$(VERSION)/g' helm/metallb/values.yaml
-	perl -pi -e 's/pullPolicy: .*/pullPolicy: IfNotPresent/g' helm/metallb/values.yaml
+	perl -pi -e 's/appVersion: .*/appVersion: $(VERSION)/g' helm-chart/Chart.yaml
+	perl -pi -e 's/tag: .*/tag: v$(VERSION)/g' helm-chart/values.yaml
+	perl -pi -e 's/pullPolicy: .*/pullPolicy: IfNotPresent/g' helm-chart/values.yaml
 
 	+make manifest
 	perl -pi -e 's/MetalLB .*/MetalLB v$(VERSION)/g' website/content/_header.md

--- a/helm-chart/.helmignore
+++ b/helm-chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+version: 0.3.0
+
+name: metallb
+appVersion: 0.5.0
+description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
+keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
+home: https://metallb.universe.tf
+icon: https://metallb.universe.tf/images/logo.png
+maintainers:
+- name: danderson
+  email: dave@natulte.net

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-version: 0.3.0
+version: 0.4.0
 
 name: metallb
-appVersion: 0.5.0
+appVersion: 0.0.0
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
 home: https://metallb.universe.tf

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,0 +1,118 @@
+MetalLB
+-------
+
+MetalLB is a load-balancer implementation for bare
+metal [Kubernetes](https://kubernetes.io) clusters, using standard
+routing protocols.
+
+TL;DR;
+------
+
+```console
+$ helm install --name metallb stable/metallb
+```
+
+Introduction
+------------
+
+This chart bootstraps a [MetalLB](https://metallb.universe.tf)
+installation on a [Kubernetes](http://kubernetes.io) cluster using
+the [Helm](https://helm.sh) package manager. This chart provides an
+implementation for LoadBalancer Service objects.
+
+MetalLB is a cluster service, and as such can only be deployed as a
+cluster singleton. Running multiple installations of MetalLB in a
+single cluster is not supported.
+
+Prerequisites
+-------------
+
+-	Kubernetes 1.9+
+
+Installing the Chart
+--------------------
+
+The chart can be installed as follows:
+
+```console
+$ helm install --name metallb stable/metallb
+```
+
+The command deploys MetalLB on the Kubernetes cluster. This chart does
+not provide a default configuration, MetalLB will not act on your
+Kubernetes Services until you provide
+one. The [configuration](#configuration) section lists various ways to
+provide this configuration.
+
+Uninstalling the Chart
+----------------------
+
+To uninstall/delete the `metallb` deployment:
+
+```console
+$ helm delete metallb
+```
+
+The command removes all the Kubernetes components associated with the
+chart and deletes the release.
+
+Configuration
+-------------
+
+See `values.yaml` for configuration notes. Specify each parameter
+using the `--set key=value[,key=value]` argument to `helm
+install`. For example,
+
+```console
+$ helm install --name metallb \
+  --set rbac.create=false \
+    stable/metallb
+```
+
+The above command disables the use of RBAC rules.
+
+Alternatively, a YAML file that specifies the values for the above
+parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name metallb -f values.yaml stable/metallb
+```
+
+By default, this chart does not install a configuration for MetalLB,
+and simply warns you that you must
+follow
+[the configuration instructions on MetalLB's website](https://metallb.universe.tf/configuration/) to
+create an appropriate ConfigMap.
+
+For simple setups that only use
+MetalLB's [ARP mode](https://metallb.universe.tf/concepts/arp-ndp/),
+you can specify a single IP range using the `arpAddresses` parameter
+to have the chart install a working configuration for you:
+
+```console
+$ helm install --name metallb \
+  --set arpAddresses=192.168.16.240/30 \
+  stable/metallb
+```
+
+If you have a more complex configuration and want Helm to manage it
+for you, you can provide it in the `config` parameter. The
+configuration format
+is
+[documented on MetalLB's website](https://metallb.universe.tf/configuration/).
+
+```console
+$ cat values.yaml
+config:
+  peers:
+  - peer-address: 10.0.0.1
+    peer-asn: 64512
+    my-asn: 64512
+  address-pools:
+  - name: default
+    protocol: bgp
+    cidr:
+    - 198.51.100.0/24
+
+$ helm install --name metallb -f values.yaml stable/metallb
+```

--- a/helm-chart/templates/NOTES.txt
+++ b/helm-chart/templates/NOTES.txt
@@ -1,0 +1,14 @@
+
+MetalLB is now running in the cluster.
+{{ if .Values.arpAddresses -}}
+LoadBalancer Services in your cluster are now available on IPs
+within {{ .Values.arpAddresses }}. To see the IP assignments,
+try `kubectl get services`.
+{{- else if .Values.config }}
+LoadBalancer Services in your cluster are now available on the IPs you
+defined in MetalLB's configuration. To see IP assignments,
+try `kubectl get services`.
+{{- else }}
+WARNING: you did not provide a configuration for MetalLB. LoadBalancer
+services will not function until you provide a configuration.
+{{- end }}

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metallb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metallb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metallb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "metallb.controllerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.controller.create -}}
+    {{ default (printf "%s-controller" (include "metallb.fullname" .)) .Values.serviceAccounts.controller.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.controller.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the speaker service account to use
+*/}}
+{{- define "metallb.speakerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.speaker.create -}}
+    {{ default (printf "%s-speaker" (include "metallb.fullname" .)) .Values.serviceAccounts.speaker.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.speaker.name }}
+{{- end -}}
+{{- end -}}

--- a/helm-chart/templates/config.yaml
+++ b/helm-chart/templates/config.yaml
@@ -1,0 +1,22 @@
+{{- if (or .Values.config .Values.arpAddresses) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metallb.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+data:
+  config: |
+{{- if .Values.config }}
+{{ toYaml .Values.config | indent 4 }}
+{{- else }}
+    address-pools:
+    - name: default
+      protocol: arp
+      cidr:
+      - {{ .Values.arpAddresses }}
+{{- end }}
+{{- end }}

--- a/helm-chart/templates/controller.yaml
+++ b/helm-chart/templates/controller.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "metallb.fullname" . }}-controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+    component: controller
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: {{ template "metallb.name" . }}
+      component: controller
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: {{ template "metallb.chart" . }}
+        app: {{ template "metallb.name" . }}
+        component: controller
+{{- if .Values.prometheus.scrapeAnnotations }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "metallb.controllerServiceAccountName" . }}
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+      - name: controller
+        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+        imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        args:
+        - --port=7472
+        - --config={{ template "metallb.fullname" . }}
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+{{ toYaml .Values.controller.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true

--- a/helm-chart/templates/rbac.yaml
+++ b/helm-chart/templates/rbac.yaml
@@ -1,0 +1,146 @@
+{{- if .Values.rbac.create -}}
+
+# Roles
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "metallb.fullname" . }}:controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["services/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "metallb.fullname" . }}:speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["services", "endpoints", "nodes"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "metallb.fullname" . }}-leader-election
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  resourceNames: ["metallb-speaker"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "metallb.fullname" . }}-config-watcher
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+
+## Role bindings
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}:controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "metallb.fullname" . }}:controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}:speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "metallb.fullname" . }}:speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}-config-watcher
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+- kind: ServiceAccount
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "metallb.fullname" . }}-config-watcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}-leader-election
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "metallb.fullname" . }}-leader-election
+{{- end -}}

--- a/helm-chart/templates/rbac.yaml
+++ b/helm-chart/templates/rbac.yaml
@@ -19,7 +19,7 @@ rules:
   verbs: ["update"]
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"]
+  verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm-chart/templates/service-accounts.yaml
+++ b/helm-chart/templates/service-accounts.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceAccounts.controller.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+{{- end }}
+---
+{{- if .Values.serviceAccounts.speaker.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+{{- end }}

--- a/helm-chart/templates/speaker.yaml
+++ b/helm-chart/templates/speaker.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: {{ template "metallb.fullname" . }}-speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+    component: speaker
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "metallb.name" . }}
+      component: speaker
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: {{ template "metallb.chart" . }}
+        app: {{ template "metallb.name" . }}
+        component: speaker
+{{- if .Values.prometheus.scrapeAnnotations }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: speaker
+        image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag }}
+        imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
+        args:
+        - --port=7472
+        - --config={{ template "metallb.fullname" . }}
+        env:
+        - name: METALLB_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+{{ toYaml .Values.speaker.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - all
+            add:
+            - net_raw

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,0 +1,67 @@
+# Default values for metallb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# config is the MetalLB configuration, in YAML format. Refer to
+# https://metallb.universe.tf/configuration/ for available options.
+config:
+
+# When arpAddresses is specified instead of config, the chart will
+# install a trivial "quick start" MetalLB configuration that uses ARP
+# mode. Refer to https://metallb.universe.tf/ for more
+# information. For production configurations, use of the `config`
+# field is recommended instead of arpAddresses.
+arpAddresses:
+
+rbac:
+  # create specifies whether to install and use RBAC rules.
+  create: true
+
+prometheus:
+  # scrape annotations specifies whether to add Prometheus metric
+  # auto-collection annotations to pods. See
+  # https://github.com/prometheus/prometheus/blob/release-2.1/documentation/examples/prometheus-kubernetes.yml
+  # for a corresponding Prometheus configuration.  Alternatively, you
+  # may want to use the Prometheus Operator
+  # (https://github.com/coreos/prometheus-operator) for more powerful
+  # monitoring configuration. If you use the Prometheus operator, this
+  # can be left at false.
+  scrapeAnnotations: false
+
+serviceAccounts:
+  controller:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.  If not set and create is
+    # true, a name is generated using the fullname template
+    name:
+  speaker:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.  If not set and create is
+    # true, a name is generated using the fullname template
+    name:
+
+# controller contains configuration specific to the MetalLB cluster
+# controller.
+controller:
+  image:
+    repository: metallb/controller
+    tag: v0.5.0
+    pullPolicy: IfNotPresent
+  resources:
+    # limits:
+      # cpu: 100m
+      # memory: 100Mi
+
+# controller contains configuration specific to the MetalLB speaker
+# daemonset.
+speaker:
+  image:
+    repository: metallb/speaker
+    tag: v0.5.0
+    pullPolicy: IfNotPresent
+  resources:
+    # limits:
+      # cpu: 100m
+      # memory: 100Mi

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -47,8 +47,8 @@ serviceAccounts:
 controller:
   image:
     repository: metallb/controller
-    tag: v0.5.0
-    pullPolicy: IfNotPresent
+    tag: master
+    pullPolicy: Always
   resources:
     # limits:
       # cpu: 100m
@@ -59,8 +59,8 @@ controller:
 speaker:
   image:
     repository: metallb/speaker
-    tag: v0.5.0
-    pullPolicy: IfNotPresent
+    tag: master
+    pullPolicy: Always
   resources:
     # limits:
       # cpu: 100m

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -1,31 +1,34 @@
----
-# Source: metallb/templates/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: metallb-system
-
+  labels:
+    app: metallb
 ---
-## Service accounts
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: metallb-system
   name: controller
+  labels:
+    app: metallb
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: metallb-system
   name: speaker
+  labels:
+    app: metallb
 
 ---
-# Source: metallb/templates/rbac.yaml
-# Roles
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metallb-system:controller
+  labels:
+    app: metallb
 rules:
 - apiGroups: [""]
   resources: ["services"]
@@ -41,6 +44,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metallb-system:speaker
+  labels:
+    app: metallb
 rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
@@ -51,6 +56,8 @@ kind: Role
 metadata:
   namespace: metallb-system
   name: leader-election
+  labels:
+    app: metallb
 rules:
 - apiGroups: [""]
   resources: ["endpoints"]
@@ -65,6 +72,8 @@ kind: Role
 metadata:
   namespace: metallb-system
   name: config-watcher
+  labels:
+    app: metallb
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -79,10 +88,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metallb-system:controller
+  labels:
+    app: metallb
 subjects:
 - kind: ServiceAccount
-  namespace: metallb-system
   name: controller
+  namespace: metallb-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -92,10 +103,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metallb-system:speaker
+  labels:
+    app: metallb
 subjects:
 - kind: ServiceAccount
-  namespace: metallb-system
   name: speaker
+  namespace: metallb-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -106,6 +119,8 @@ kind: RoleBinding
 metadata:
   namespace: metallb-system
   name: config-watcher
+  labels:
+    app: metallb
 subjects:
 - kind: ServiceAccount
   name: controller
@@ -121,6 +136,8 @@ kind: RoleBinding
 metadata:
   namespace: metallb-system
   name: leader-election
+  labels:
+    app: metallb
 subjects:
 - kind: ServiceAccount
   name: speaker
@@ -129,7 +146,6 @@ roleRef:
   kind: Role
   name: leader-election
 ---
-# Source: metallb/templates/speaker.yaml
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
@@ -157,7 +173,7 @@ spec:
       hostNetwork: true
       containers:
       - name: speaker
-        image: metallb/speaker:latest
+        image: metallb/speaker:master
         imagePullPolicy: Always
         args:
         - --port=7472
@@ -186,8 +202,8 @@ spec:
             - all
             add:
             - net_raw
+
 ---
-# Source: metallb/templates/controller.yaml
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -196,9 +212,6 @@ metadata:
   labels:
     app: metallb
     component: controller
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "7472"
 spec:
   revisionHistoryLimit: 3
   selector:
@@ -210,6 +223,9 @@ spec:
       labels:
         app: metallb
         component: controller
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
     spec:
       serviceAccountName: controller
       terminationGracePeriodSeconds: 0
@@ -218,7 +234,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: controller
-        image: metallb/controller:latest
+        image: metallb/controller:master
         imagePullPolicy: Always
         args:
         - --port=7472
@@ -236,3 +252,7 @@ spec:
             drop:
             - all
           readOnlyRootFilesystem: true
+
+---
+
+

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -129,57 +129,6 @@ roleRef:
   kind: Role
   name: leader-election
 ---
-# Source: metallb/templates/controller.yaml
-apiVersion: apps/v1beta2
-kind: Deployment
-metadata:
-  namespace: metallb-system
-  name: controller
-  labels:
-    app: metallb
-    component: controller
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "7472"
-spec:
-  revisionHistoryLimit: 3
-  selector:
-    matchLabels:
-      app: metallb
-      component: controller
-  template:
-    metadata:
-      labels:
-        app: metallb
-        component: controller
-    spec:
-      serviceAccountName: controller
-      terminationGracePeriodSeconds: 0
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534 # nobody
-      containers:
-      - name: controller
-        image: metallb/controller:latest
-        imagePullPolicy: Always
-        args:
-        - --port=7472
-        ports:
-        - name: monitoring
-          containerPort: 7472
-        resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
-          
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          readOnlyRootFilesystem: true
-
----
 # Source: metallb/templates/speaker.yaml
 apiVersion: apps/v1beta2
 kind: DaemonSet
@@ -237,4 +186,53 @@ spec:
             - all
             add:
             - net_raw
-
+---
+# Source: metallb/templates/controller.yaml
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  namespace: metallb-system
+  name: controller
+  labels:
+    app: metallb
+    component: controller
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "7472"
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+  template:
+    metadata:
+      labels:
+        app: metallb
+        component: controller
+    spec:
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+      - name: controller
+        image: metallb/controller:latest
+        imagePullPolicy: Always
+        args:
+        - --port=7472
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -6,6 +6,20 @@ metadata:
   name: metallb-system
 
 ---
+## Service accounts
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: metallb-system
+  name: controller
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: metallb-system
+  name: speaker
+
+---
 # Source: metallb/templates/rbac.yaml
 # Roles
 apiVersion: rbac.authorization.k8s.io/v1
@@ -58,20 +72,6 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create"]
----
-
-## Service accounts
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  namespace: metallb-system
-  name: controller
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  namespace: metallb-system
-  name: speaker
 ---
 
 ## Role bindings

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    app: metallb

--- a/website/content/community/release-process.md
+++ b/website/content/community/release-process.md
@@ -79,6 +79,13 @@ tags that don't exist until CircleCI makes them exist.
 Check on Docker Hub for a `vX.Y.Z` tag on each image, or check on
 CircleCI that the deploy has completed.
 
+### Update the official Helm chart
+
+Clone https://github.com/kubernetes/charts , and overwrite the
+`stable/metallb` directory with the contents of `helm-chart` from the
+release branch. Send as a PR. In the meantime, bump the chart version
+in master for the next time.
+
 ### Repoint the live website
 
 Move the `live-website` branch to the newly created tag with `git


### PR DESCRIPTION
Having the helm chart here means we can prepare changes to the chart in lockstep with other changes to MetalLB. It does add a release step, in that we have to go back and resync the official chart.