### PR TITLE
 Helm: Add support for nodeSelector/tolerations/affinity

### DIFF
--- a/helm-chart/templates/controller.yaml
+++ b/helm-chart/templates/controller.yaml
@@ -34,6 +34,18 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534 # nobody
+    {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       containers:
       - name: controller
         image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}

--- a/helm-chart/templates/speaker.yaml
+++ b/helm-chart/templates/speaker.yaml
@@ -60,3 +60,15 @@ spec:
             - all
             add:
             - net_raw
+    {{- with .Values.speaker.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.speaker.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.speaker.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -58,6 +58,9 @@ controller:
     # limits:
       # cpu: 100m
       # memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 # controller contains configuration specific to the MetalLB speaker
 # daemonset.
@@ -70,3 +73,6 @@ speaker:
     # limits:
       # cpu: 100m
       # memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -39,13 +39,13 @@ serviceAccounts:
     create: true
     # The name of the ServiceAccount to use.  If not set and create is
     # true, a name is generated using the fullname template
-    name:
+    name: ""
   speaker:
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.  If not set and create is
     # true, a name is generated using the fullname template
-    name:
+    name: ""
 
 # controller contains configuration specific to the MetalLB cluster
 # controller.
@@ -54,7 +54,7 @@ controller:
     repository: metallb/controller
     tag: master
     pullPolicy: Always
-  resources:
+  resources: {}
     # limits:
       # cpu: 100m
       # memory: 100Mi
@@ -66,7 +66,7 @@ speaker:
     repository: metallb/speaker
     tag: master
     pullPolicy: Always
-  resources:
+  resources: {}
     # limits:
       # cpu: 100m
       # memory: 100Mi


### PR DESCRIPTION
This allows setting the `nodeSelector`, `tolerations` and `affinity` for both the speaker
and controller. This is useful for limiting the nodes that the speaker daemons pods are run on.

Default values are also set in `values.yaml` so that the yaml is well-formed.

Closes #222