### PR TITLE
Correctly use AS_SEQUENCE in path attributes.

### DIFF
--- a/e2etest/e2e_setup_test.go
+++ b/e2etest/e2e_setup_test.go
@@ -104,7 +104,6 @@ func runTests(m *testing.M) int {
 		}()
 	}
 	if *build {
-		clusterName := fmt.Sprintf("%s-%s-%s", *pfx, *proto, *addon)
 		if err := terraformDestroy(*gcpProject, clusterName); err != nil {
 			log.Printf("pre-bringup cleanup of %q failed: %s", clusterName, err)
 			return 1

--- a/internal/bgp/messages.go
+++ b/internal/bgp/messages.go
@@ -338,7 +338,7 @@ func encodePathAttrs(b *bytes.Buffer, asn uint32, defaultNextHop net.IP, adv *Ad
 	} else {
 		b.Write([]byte{
 			6, // len
-			1, // AS_SET
+			2, // AS_SEQUENCE
 			1, // len (in number of ASes)
 		})
 		if err := binary.Write(b, binary.BigEndian, asn); err != nil {


### PR DESCRIPTION
The spec requires route originators to specify their ASN
in an AS_SEQUENCE path segment (which makes sense if you
think about it... AS_SET encodes a path that goes "via one
of these ASNs", which is impossible fo the *originating* ASN).

Fixes #225.
