### PR TITLE
Listen on all structurally valid interfaces, regardless of addresses.

### DIFF
--- a/internal/layer2/arp_test.go
+++ b/internal/layer2/arp_test.go
@@ -157,6 +157,7 @@ func newTestARP(t *testing.T, shouldAnnounce announceFunc) (*arpResponder, *net.
 		a = &arpResponder{
 			hardwareAddr: intf.HardwareAddr,
 			conn:         c,
+			closed:       make(chan struct{}),
 			announce:     shouldAnnounce,
 		}
 	}


### PR DESCRIPTION
There is a valid use case for having interfaces that are "services-only",
i.e. are marked up, but don't have global unicast addresses of their own.
Such addresses can still participate in layer2 mode advertisements, and
it can significantly save on the number of IPs in use on the network.

This change therefore listens on all interfaces that are up and support
the features required by ARP/NDP (e.g. broadcast, multicast, existence
of a link-local address...).

Fixes #226 