### PR TITLE
Clean up old code related to layer2 interface selection. #226

### DIFF
--- a/helm-chart/templates/speaker.yaml
+++ b/helm-chart/templates/speaker.yaml
@@ -39,10 +39,6 @@ spec:
         - --port=7472
         - --config={{ template "metallb.configMapName" . }}
         env:
-        - name: METALLB_NODE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
         - name: METALLB_NODE_NAME
           valueFrom:
             fieldRef:

--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -19,9 +19,7 @@ type Announce struct {
 }
 
 // New returns an initialized Announce.
-func New(ifi *net.Interface) (*Announce, error) {
-	glog.Infof("creating layer 2 announcer on interface %q", ifi.Name)
-
+func New() (*Announce, error) {
 	ret := &Announce{
 		arps: map[int]*arpResponder{},
 		ndps: map[int]*ndpResponder{},

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -179,10 +179,6 @@ spec:
         - --port=7472
         - --config=config
         env:
-        - name: METALLB_NODE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
         - name: METALLB_NODE_NAME
           valueFrom:
             fieldRef:

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -171,7 +171,6 @@ func TestBGPSpeaker(t *testing.T) {
 	}
 	newBGP = b.New
 	c, err := newController(controllerConfig{
-		NodeIP:        net.ParseIP("1.2.3.4"),
 		MyNode:        "pandora",
 		DisableLayer2: true,
 	})
@@ -750,7 +749,6 @@ func TestNodeSelectors(t *testing.T) {
 	}
 	newBGP = b.New
 	c, err := newController(controllerConfig{
-		NodeIP:        net.ParseIP("1.2.3.4"),
 		MyNode:        "pandora",
 		DisableLayer2: true,
 	})


### PR DESCRIPTION
There's no longer any need to pass in the node IP, or look up the
relevant interface.