### PR TITLE
Hide glog's flags from the commandline. #189

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:latest
 
 ADD controller /controller
-ENTRYPOINT ["/controller", "--logtostderr"]
+ENTRYPOINT ["/controller"]

--- a/controller/main.go
+++ b/controller/main.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 
 	"go.universe.tf/metallb/internal/allocator"
@@ -122,10 +123,20 @@ func (c *controller) MarkSynced() {
 }
 
 func main() {
-	kubeconfig := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	master := flag.String("master", "", "master url")
-	port := flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
-	config := flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
+	// glog is a hostile package that registers a bunch of flags and
+	// does forced initialization outside of the program's
+	// control. This is a huge workaround to just make it log to
+	// stderr as well as we can, and then hide all the crap it
+	// defined.
+	flag.Set("logtostderr", "true")
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	var (
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+		master     = flag.String("master", "", "master url")
+		port       = flag.Int("port", 7472, "HTTP listening port for Prometheus metrics")
+		config     = flag.String("config", "config", "Kubernetes ConfigMap containing MetalLB's configuration")
+	)
 	flag.Parse()
 
 	glog.Infof("MetalLB controller %s", version.String())

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:latest
 
 ADD speaker /speaker
-ENTRYPOINT ["/speaker", "--logtostderr"]
+ENTRYPOINT ["/speaker"]

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -47,6 +47,14 @@ var announcing = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 func main() {
 	prometheus.MustRegister(announcing)
 
+	// glog is a hostile package that registers a bunch of flags and
+	// does forced initialization outside of the program's
+	// control. This is a huge workaround to just make it log to
+	// stderr as well as we can, and then hide all the crap it
+	// defined.
+	flag.Set("logtostderr", "true")
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	var (
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 		master     = flag.String("master", "", "master url")


### PR DESCRIPTION
We are fortunate, in that we only register flags in main.go, so we can
just overwrite the base commandline flag set with a new one, which
effectively hides all flags that weren't defined in main(). Just before
doing that, we set --logtostderr=true for glog, so that it doesn't try
to do file I/O other than writing to os.Stderr.

This is step one of trying to remove glog from MetalLB.