### PR TITLE
This PR adds support for TCP MD5 auth in metallb.

### DIFF
--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -536,7 +536,6 @@ func (d *TCPDialer) DialTCP(tcphost string, port int ) (*net.TCPConn, error) {
 	proto := 0
 	fd, err := syscall.Socket(family, sockType, proto)
 	if err != nil {
-	        glog.Errorf(" syscall.socket %s ",  err)
 		return nil, err
 	}
 	fi := os.NewFile(uintptr(fd), "")

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -167,7 +167,7 @@ func (s *Session) connect() error {
 
 	d := TCPDialer{
 		Dialer: net.Dialer{
-			Timeout:  10,
+			Timeout:  10 * time.Second,
 			Deadline: deadline,
 		},
 		AuthPassword: s.password,

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -458,7 +458,7 @@ const (
 // This  struct is defined at; linux-kernel: include/uapi/linux/tcp.h,
 // It  must be kept in sync with that definition, see current version:
 // https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/tcp.h#L253
-// nolint
+// nolint[structcheck]
 type tcpmd5sig struct {
 	ssFamily uint16
 	ss       [126]byte

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -563,7 +563,7 @@ func (d *TCPDialer) DialTCP(tcphost string, port int, timeout int) (net.Conn, er
 	}
 
 	if timeout != 0 {
-		if err = setsockoptIPTTL(fd, family, int(timeout)); err != nil {
+		if err = setsockoptIPTTL(fd, family, timeout); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -458,6 +458,7 @@ const (
 // This  struct is defined at; linux-kernel: include/uapi/linux/tcp.h,
 // It  must be kept in sync with that definition, see current version:
 // https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/tcp.h#L253
+// nolint
 type tcpmd5sig struct {
 	ssFamily uint16
 	ss       [126]byte

--- a/internal/bgp/bgp_test.go
+++ b/internal/bgp/bgp_test.go
@@ -113,17 +113,62 @@ func TestInterop(t *testing.T) {
 	}
 }
 
+func runGoBGPTCPMD5(ctx context.Context) (chan *table.Path, error) {
+	s := gobgp.NewBgpServer()
+	go s.Serve()
+
+	global := &config.Global{
+		Config: config.GlobalConfig{
+			As:       64543,
+			RouterId: "1.2.3.4",
+			Port:     5179,
+		},
+	}
+	if err := s.Start(global); err != nil {
+		return nil, err
+	}
+
+	n := &config.Neighbor{
+		Config: config.NeighborConfig{
+			NeighborAddress: "127.0.0.1",
+			PeerAs:          64543,
+			AuthPassword:    "somepassword",
+		},
+	}
+	if err := s.AddNeighbor(n); err != nil {
+		return nil, err
+	}
+	ips := make(chan *table.Path, 1000)
+	w := s.Watch(gobgp.WatchBestPath(false))
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev := <-w.Event():
+				switch msg := ev.(type) {
+				case *gobgp.WatchEventBestPath:
+					for _, path := range msg.PathList {
+						ips <- path
+					}
+				}
+			}
+		}
+	}()
+	return ips, nil
+}
+
 func TestTCPMD5(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	ips, err := runGoBGP(ctx)
+	ips, err := runGoBGPTCPMD5(ctx)
 	if err != nil {
 		t.Fatalf("starting GoBGP: %s", err)
 	}
 
 	l := log.NewNopLogger()
-	sess, err := New(l, "127.0.0.1:4181", 64543, net.ParseIP("2.3.4.6"), 64543, 10*time.Second, "somepassword")
+	sess, err := New(l, "127.0.0.1:5179", 64543, net.ParseIP("2.3.4.6"), 64543, 10*time.Second, "somepassword")
 	if err != nil {
 		t.Fatalf("starting BGP session to GoBGP: %s", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ type peer struct {
 	HoldTime      string         `yaml:"hold-time"`
 	RouterID      string         `yaml:"router-id"`
 	NodeSelectors []nodeSelector `yaml:"node-selectors"`
+	Password      string         `yaml:"password"`
 }
 
 type nodeSelector struct {
@@ -107,6 +108,7 @@ type Peer struct {
 	// selectors.
 	NodeSelectors []labels.Selector
 
+	Password  string
 	// TODO: more BGP session settings
 }
 
@@ -284,6 +286,10 @@ func parsePeer(p peer) (*Peer, error) {
 		}
 	}
 
+	var password string
+	if p.Password != "" {
+              password = p.Password
+        }
 	return &Peer{
 		MyASN:         p.MyASN,
 		ASN:           p.ASN,
@@ -292,6 +298,7 @@ func parsePeer(p peer) (*Peer, error) {
 		HoldTime:      holdTime,
 		RouterID:      routerID,
 		NodeSelectors: nodeSels,
+		Password:	password,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,8 +107,8 @@ type Peer struct {
 	// Only connect to this peer on nodes that match one of these
 	// selectors.
 	NodeSelectors []labels.Selector
-
-	Password  string
+	// Authentication password for routers enforcing TCP MD5 authenticated sessions
+	Password string
 	// TODO: more BGP session settings
 }
 
@@ -288,8 +288,8 @@ func parsePeer(p peer) (*Peer, error) {
 
 	var password string
 	if p.Password != "" {
-              password = p.Password
-        }
+		password = p.Password
+	}
 	return &Peer{
 		MyASN:         p.MyASN,
 		ASN:           p.ASN,
@@ -298,7 +298,7 @@ func parsePeer(p peer) (*Peer, error) {
 		HoldTime:      holdTime,
 		RouterID:      routerID,
 		NodeSelectors: nodeSels,
-		Password:	password,
+		Password:      password,
 	}, nil
 }
 

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -108,3 +108,7 @@ data:
       # re-advertisement outside of the immediate autonomous system,
       # but people don't usually recognize its numerical value. :)
       no-export: 65535:65281
+    # (optional) Password for  TCPMD5  authenticated BGP sessions
+    # offered by some peers.
+    # Uncomment this line and fill it with your password
+    #password: "yourPassword"

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -25,6 +25,9 @@ data:
       # to the node IP address. Generally only useful when you need to peer with
       # another BGP router running on the same machine as MetalLB.
       router-id: 1.2.3.4
+      # (optional) Password for  TCPMD5  authenticated BGP sessions
+      # offered by some peers.
+      password: "yourPassword"
       # (optional) The nodes that should connect to this peer. A node
       # matches if at least one of the node selectors matches. Within
       # one selector, a node matches if all the matchers are
@@ -108,7 +111,3 @@ data:
       # re-advertisement outside of the immediate autonomous system,
       # but people don't usually recognize its numerical value. :)
       no-export: 65535:65281
-    # (optional) Password for  TCPMD5  authenticated BGP sessions
-    # offered by some peers.
-    # Uncomment this line and fill it with your password
-    #password: "yourPassword"

--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -25,7 +25,7 @@ data:
       # to the node IP address. Generally only useful when you need to peer with
       # another BGP router running on the same machine as MetalLB.
       router-id: 1.2.3.4
-      # (optional) Password for  TCPMD5  authenticated BGP sessions
+      # (optional) Password for TCPMD5 authenticated BGP sessions
       # offered by some peers.
       password: "yourPassword"
       # (optional) The nodes that should connect to this peer. A node

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -114,7 +114,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := newBGP(c.logger, fmt.Sprintf("%s:%d", p.cfg.Addr, p.cfg.Port), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime)
+			s, err := newBGP(c.logger, fmt.Sprintf("%s:%d", p.cfg.Addr, p.cfg.Port), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password)
 			if err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
@@ -216,6 +216,6 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 	return c.syncPeers(l)
 }
 
-var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration) (session, error) {
-	return bgp.New(logger, addr, myASN, routerID, asn, hold)
+var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string) (session, error) {
+	return bgp.New(logger, addr, myASN, routerID, asn, hold, password)
 }

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -93,7 +93,7 @@ type fakeBGP struct {
 	gotAds map[string][]*bgp.Advertisement
 }
 
-func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration) (session, error) {
+func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _ string) (session, error) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/website/content/configuration/_index.md
+++ b/website/content/configuration/_index.md
@@ -97,7 +97,7 @@ specific than `/24`. So, you need to somehow advertise a `/24` to your
 transit provider, but still have the ability to do per-IP routing
 internally.
 
-Here's a configuration that implemnents this:
+Here's a configuration that implements this:
 
 ```yaml
 apiVersion: v1
@@ -120,7 +120,7 @@ data:
       - aggregation-length: 32
         localpref: 100
         communities:
-        - no-avertise
+        - no-advertise
       - aggregation-length: 24
     bgp-communities:
       no-advertise: 65535:65282


### PR DESCRIPTION
The default net.Conn object is replaced by  low level
syscalls that create the FD's set the sockopts directly,
as TCP MD5  sockopts have to be set before the connection
is made.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:
This PR attempts to provide a new feature TCP MD5  BGP auth, 



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes # #215 



**Special notes for your reviewer**:
This is of course a my first interaction with GOLANG,  not perfect, but done is better than missing. 
There is code and inspiration from gopgp, expect some similarities. 