### PR TITLE
Fire the "synced" callback if it's registered.

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -257,6 +257,10 @@ func New(cfg *Config) (*Client, error) {
 		c.leaderChanged = cfg.LeaderChanged
 	}
 
+	if cfg.Synced != nil {
+		c.synced = cfg.Synced
+	}
+
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
 		http.ListenAndServe(fmt.Sprintf(":%d", cfg.MetricsPort), nil)


### PR DESCRIPTION
Oops, this broke IP allocation in the controller. Oh well.