### PR TITLE
Document that the Helm chart is currently outdated.

### DIFF
--- a/website/content/installation/_index.md
+++ b/website/content/installation/_index.md
@@ -43,6 +43,10 @@ you
 Due to code review turnaround time, it usually takes a few days after
 each MetalLB release before the Helm chart is updated in the stable
 repository.
+
+Currently, the Helm chart is **not** up to date with the latest
+release of MetalLB. If you need to use the latest release, please use
+an alternate installation method.
 {{% /notice %}}
 
 MetalLB maintains a Helm package in the `stable` package


### PR DESCRIPTION
Code review latency seems to be >1w right now, so I need to set
appropriate expectations for MetalLB's users.