### PR TITLE
Check for closed or aborted BGP sessions before sending the initial BGP update

### DIFF
--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -75,6 +75,13 @@ func (s *Session) sendUpdates() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if s.closed {
+		return false
+	}
+	if s.conn == nil {
+		return true
+	}
+
 	asn := s.asn
 	if s.peerASN == s.asn {
 		asn = 0


### PR DESCRIPTION
Fixes #250