### PR TITLE
Log error messages encountered during ConfigMap parsing

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -411,13 +411,13 @@ func (c *Client) sync(key interface{}) bool {
 		cm := cmi.(*v1.ConfigMap)
 		cfg, err := config.Parse([]byte(cm.Data["config"]))
 		if err != nil {
-			l.Log("event", "configStale", "msg", "config (re)load failed, config marked stale")
+			l.Log("event", "configStale", "error", err, "msg", "config (re)load failed, config marked stale")
 			configStale.Set(1)
 			return true
 		}
 
 		if !c.configChanged(l, cfg) {
-			l.Log("event", "configStale", "msg", "config (re)load failed, config marked stale")
+			l.Log("event", "configStale", "error", err, "msg", "config (re)load failed, config marked stale")
 			configStale.Set(1)
 			return true
 		}


### PR DESCRIPTION
Thank you for this wonderful software!

**What this PR does / why we need it**: This change restores the logging of error messages that were removed when these logs were moved from glog to go-kit in https://github.com/google/metallb/commit/462b4758763d68f1a7a66998026a24847d9ed42a. This should help other users track down issues with config moving from 0.5.x to 0.6.x

It looks like there is a request for better error config parsing messages overall in https://github.com/google/metallb/issues/201. This change will be necessary for those improvements but I feel that surfacing the YAML parsing errors are helpful enough to do this now. 
