### PR TITLE
Less post processing of helm chart

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -8,7 +8,7 @@ TL;DR;
 ------
 
 ```console
-$ helm install --name metallb stable/metallb
+$ helm install --name metallb --namespace metallb-system stable/metallb
 ```
 
 Introduction
@@ -33,7 +33,7 @@ Installing the Chart
 The chart can be installed as follows:
 
 ```console
-$ helm install --name metallb stable/metallb
+$ helm install --name metallb --namespace metallb-system stable/metallb
 ```
 
 The command deploys MetalLB on the Kubernetes cluster. This chart does
@@ -69,9 +69,8 @@ using the `--set key=value[,key=value]` argument to `helm
 install`. For example,
 
 ```console
-$ helm install --name metallb \
-  --set rbac.create=false \
-    stable/metallb
+$ helm install --name metallb --namespace metallb-system \
+      --set rbac.create=false stable/metallb
 ```
 
 The above command disables the use of RBAC rules.
@@ -80,7 +79,8 @@ Alternatively, a YAML file that specifies the values for the above
 parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name metallb -f values.yaml stable/metallb
+$ helm install --name metallb --namespace metallb-system \
+    -f values.yaml stable/metallb
 ```
 
 By default, this chart does not install a configuration for MetalLB, and simply
@@ -92,7 +92,7 @@ you can specify a single IP range using the `arpAddresses` parameter to have the
 chart install a working configuration for you:
 
 ```console
-$ helm install --name metallb \
+$ helm install --name metallb --namespace metallb-system \
   --set arpAddresses=192.168.16.240/30 \
   stable/metallb
 ```
@@ -114,7 +114,8 @@ config:
     cidr:
     - 198.51.100.0/24
 
-$ helm install --name metallb -f values.yaml stable/metallb
+$ helm install --name metallb --namespace metallb-system \
+    -f values.yaml stable/metallb
 ```
 
 [helm-home]: https://helm.sh

--- a/helm-chart/templates/controller.yaml
+++ b/helm-chart/templates/controller.yaml
@@ -1,11 +1,14 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "metallb.fullname" . }}-controller
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
     component: controller
 spec:
@@ -14,13 +17,17 @@ spec:
     matchLabels:
       app: {{ template "metallb.name" . }}
       component: controller
+      {{- if not .Values.manifest }}
       release: {{ .Release.Name | quote }}
+      {{- end }}
   template:
     metadata:
       labels:
+        {{- if not .Values.manifest }}
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
         chart: {{ template "metallb.chart" . }}
+        {{- end }}
         app: {{ template "metallb.name" . }}
         component: controller
 {{- if .Values.prometheus.scrapeAnnotations }}

--- a/helm-chart/templates/rbac.yaml
+++ b/helm-chart/templates/rbac.yaml
@@ -6,9 +6,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "metallb.fullname" . }}:controller
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 rules:
 - apiGroups: [""]
@@ -26,9 +28,11 @@ kind: ClusterRole
 metadata:
   name: {{ template "metallb.fullname" . }}:speaker
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 rules:
 - apiGroups: [""]
@@ -38,11 +42,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "metallb.fullname" . }}-leader-election
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 rules:
 - apiGroups: [""]
@@ -56,11 +63,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 rules:
 - apiGroups: [""]
@@ -77,9 +87,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "metallb.fullname" . }}:controller
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
@@ -95,9 +107,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "metallb.fullname" . }}:speaker
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
@@ -111,11 +125,14 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
@@ -130,11 +147,14 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "metallb.fullname" . }}-leader-election
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount

--- a/helm-chart/templates/service-accounts.yaml
+++ b/helm-chart/templates/service-accounts.yaml
@@ -2,11 +2,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "metallb.controllerServiceAccountName" . }}
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 {{- end }}
 ---
@@ -14,10 +17,13 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "metallb.speakerServiceAccountName" . }}
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
 {{- end }}

--- a/helm-chart/templates/speaker.yaml
+++ b/helm-chart/templates/speaker.yaml
@@ -1,11 +1,14 @@
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "metallb.fullname" . }}-speaker
   labels:
+    {{- if not .Values.manifest }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
+    {{- end }}
     app: {{ template "metallb.name" . }}
     component: speaker
 spec:
@@ -13,13 +16,17 @@ spec:
     matchLabels:
       app: {{ template "metallb.name" . }}
       component: speaker
+      {{- if not .Values.manifest }}
       release: {{ .Release.Name | quote }}
+      {{- end }}
   template:
     metadata:
       labels:
+        {{- if not .Values.manifest }}
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
         chart: {{ template "metallb.chart" . }}
+        {{- end }}
         app: {{ template "metallb.name" . }}
         component: speaker
 {{- if .Values.prometheus.scrapeAnnotations }}


### PR DESCRIPTION
The implicit namespace required post processing when making the
manifest, made it explicit in the chart and remove some post processing

helm specific labels are conditionally hidden when
value of manifest is true

updated README to suggest the --namespace argument

Changes to the manifest Makefile target:
* builds in a single pipeline
* much more readable
* some string replacements are no longer needed