### PR TITLE
Fix for issue #301

### DIFF
--- a/controller/service.go
+++ b/controller/service.go
@@ -120,7 +120,7 @@ func (c *controller) clearServiceState(key string, svc *v1.Service) {
 func (c *controller) allocateIP(key string, svc *v1.Service) (net.IP, error) {
 	// If the user asked for a specific IP, try that.
 	if svc.Spec.LoadBalancerIP != "" {
-		ip := net.ParseIP(svc.Spec.LoadBalancerIP).To4()
+		ip := net.ParseIP(svc.Spec.LoadBalancerIP)
 		if ip == nil {
 			return nil, fmt.Errorf("invalid spec.loadBalancerIP %q", svc.Spec.LoadBalancerIP)
 		}


### PR DESCRIPTION
Remove a check for ipv4 to allow also ipv6 addresses.

**What this PR does / why we need it**:

This PR removes a check that loadBalancerIP is ipv4.
It is needed to allow also ipv6 addresses. 

**Which issue(s) this PR fixes**

Fixes #301 

**Special notes for your reviewer**:

This is a very tiny fix. It is necessary for using the controller in an ipv6 k8s cluster but it is also a test of the PR procedure, especially CLA which should work now...