### PR TITLE
Ipv6; Use ipv4 address as routerId also for ipv6 clusters

### DIFF
--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -255,11 +255,11 @@ func getRouterID(addr net.IP) net.IP {
 			var ip net.IP
 			switch v := a.(type) {
 			case *net.IPNet:
-                ip = v.IP
+				ip = v.IP
 			case *net.IPAddr:
-                ip = v.IP
+				ip = v.IP
 			}
-			
+
 			if ip.Equal(addr) {
 				// This is the interface.
 				// Loop through the addresses again and search for ipv4


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR uses an ipv4 address, if it is exists, as routerID in an ipv6-only cluster. The ipv4 address is taken from the same interface as for the BGP peering (don't know if that is really necessary). It also removes usage of 0.0.0.0/0 as local address and use [::]:0 instead (this is ipv4 compatibe).

This PR makes peering possible with ipv6 peers without special configuration. It is a step towards ipv6 support for bgp #7.

Address announcement still does not work;

```
{"caller":"main.go:214","error":"cannot advertise non-v4 prefix \"\u003cnil\u003e\"","ip":"1000::","msg":"failed to announce service","op":"setBalancer","pool":"default","protocol":"bgp","service":"default/mconnect","ts":"2018-09-24T07:19:49.784240262Z"}
```

so more work is needed to support bgp for ipv6.

**Which issue(s) this PR fixes**

Please see above.

**Special notes for your reviewer**:

Please see my note in the [issue](https://github.com/google/metallb/issues/7#issuecomment-422008824).

The use of [::]:0 as local address is ipv4 compatible *but* it assumes ipv6 support in the kernel. I don't know if that is an issue, but I have seen complaints on the slack channels about it.
