### PR TITLE
Undestrand ipv6 peer addresses

### DIFF
--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"reflect"
 	"sort"
+	"strconv"
 	"time"
 
 	"go.universe.tf/metallb/internal/bgp"
@@ -153,7 +154,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := newBGP(c.logger, fmt.Sprintf("%s:%d", p.cfg.Addr, p.cfg.Port), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password)
+			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password)
 			if err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed the "too many colons" error when ipv6 addresses are used for peers.

This is another attempt at PR 239 but fixed as suggested by @danderson 

This PR is needed to get BGP peering working with ipv6 peers.

**Which issue(s) this PR fixes**

A step on the way for  #7 

**Special notes for your reviewer**:

See [pr-239](https://github.com/google/metallb/pull/239)
