### PR TITLE
Add OS nodeSelector for linux to allow for hybrid cluster.

### DIFF
--- a/helm-chart/templates/controller.yaml
+++ b/helm-chart/templates/controller.yaml
@@ -34,8 +34,9 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534 # nobody
-    {{- with .Values.controller.nodeSelector }}
       nodeSelector:
+        "beta.kubernetes.io/os": linux
+        {{- with .Values.controller.nodeSelector }}
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.controller.tolerations }}

--- a/helm-chart/templates/speaker.yaml
+++ b/helm-chart/templates/speaker.yaml
@@ -56,8 +56,9 @@ spec:
             - all
             add:
             - net_raw
-    {{- with .Values.speaker.nodeSelector }}
       nodeSelector:
+        "beta.kubernetes.io/os": linux
+        {{- with .Values.speaker.nodeSelector }}
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.speaker.tolerations }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets a nodeSelector for limiting the deployment via helm to linux OS nodes only.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #324




