### PR TITLE
Generate a router-id from a hash on the hostname as fallback

### DIFF
--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -154,7 +154,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password)
+			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
 			if err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
@@ -256,6 +256,6 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 	return c.syncPeers(l)
 }
 
-var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string) (session, error) {
-	return bgp.New(logger, addr, myASN, routerID, asn, hold, password)
+var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
+	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This may be necessary in a true ipv6-only cluster if there are no ipv4 addresses and no router-id is specified by configuration.

Since the router-id is generated there is a probability for collisions. This is however very small and (more important) predictable beforehand. Since the router-is's are dependent on hostname only and totally deterministic it is easy to write an offline program that with 100% accuracy can tell if there will be a collision given the hostnames as input.

See also; https://github.com/projectcalico/calico/issues/2229

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

A step towards fix for #7 



**Special notes for your reviewer**:

This PR also corrects a bug in PR [#318](https://github.com/google/metallb/pull/318), only the first address n the interface was checked. That happens to be the ipv4 address so tests pass but just out of luck.
