### PR TITLE
Layer 2: do not listen slave interfaces

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -2,6 +2,7 @@ package layer2
 
 import (
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -61,6 +62,9 @@ func (a *Announce) updateInterfaces() {
 		}
 
 		if ifi.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if _, err := os.Stat("/sys/class/net/" + ifi.Name + "/master"); !os.IsNotExist(err) {
 			continue
 		}
 		if ifi.Flags&net.FlagBroadcast != 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR disables listening on interfaces which have master

**Which issue(s) this PR fixes**:
Fixes #349

**Special notes for your reviewer**:
