### PR TITLE
Layer 2: do not listen slave and noarp interfaces (via netlink)

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -2,7 +2,6 @@ package layer2
 
 import (
 	"net"
-	"os"
 	"sync"
 	"time"
 
@@ -62,9 +61,6 @@ func (a *Announce) updateInterfaces() {
 		}
 
 		if ifi.Flags&net.FlagUp == 0 {
-			continue
-		}
-		if _, err := os.Stat("/sys/class/net/" + ifi.Name + "/master"); !os.IsNotExist(err) {
 			continue
 		}
 		if ifi.Flags&net.FlagBroadcast != 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:

This PR disables listening on interfaces which have master or NOARP flag set.
It also overrides previous check from #350 

**Which issue(s) this PR fixes** :

Fixes #349, #351

**Special notes for your reviewer**:

There is new library included: `github.com/vishvananda/netlink`. It's well tested too.
Kubernetes uses it in [ipvs proxier](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/ipvs/netlink_linux.go) and [kubenet](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go) projects.