### PR TITLE
Added `node-role.kubernetes.io/master:NoSchedule` to the `ds/speaker`

### DIFF
--- a/helm-chart/templates/speaker.yaml
+++ b/helm-chart/templates/speaker.yaml
@@ -28,6 +28,9 @@ spec:
         prometheus.io/port: "7472"
 {{- end }}
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -137,6 +137,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "7472"
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: speaker
       terminationGracePeriodSeconds: 0
       hostNetwork: true


### PR DESCRIPTION
Otherwise services for pods that run on master nodes would not be announced

Related: https://github.com/google/metallb/issues/371

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:
It adds the `node-role.kubernetes.io/master:NoSchedule` toleration to the `speaker` `DaemonSet` so that `speaker` was also deployed on master nods


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #371



**Special notes for your reviewer**:
