### PR TITLE
Support for PodSecurityPolicy

### DIFF
--- a/helm-chart/templates/psp.yaml
+++ b/helm-chart/templates/psp.yaml
@@ -17,7 +17,9 @@ spec:
   privileged: true
   allowPrivilegeEscalation: false
   allowedCapabilities:
+  - 'NET_ADMIN'
   - 'NET_RAW'
+  - 'SYS_ADMIN'
   volumes:
   - '*'
   fsGroup:

--- a/helm-chart/templates/psp.yaml
+++ b/helm-chart/templates/psp.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.psp.create -}}
+
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "metallb.fullname" . }}-speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+spec:
+  hostNetwork: true
+  hostPorts:
+  - min: 7472
+    max: 7472
+  privileged: true
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - 'NET_RAW'
+  volumes:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+{{- end -}}

--- a/helm-chart/templates/rbac.yaml
+++ b/helm-chart/templates/rbac.yaml
@@ -34,6 +34,12 @@ rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
   verbs: ["get", "list", "watch"]
+{{- if .Values.psp.create }}
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: [{{ printf "%s-speaker" (include "metallb.fullname" .) | quote}}]
+  verbs: ["use"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/helm-chart/templates/speaker.yaml
+++ b/helm-chart/templates/speaker.yaml
@@ -58,7 +58,9 @@ spec:
             drop:
             - ALL
             add:
+            - NET_ADMIN
             - NET_RAW
+            - SYS_ADMIN
       nodeSelector:
         "beta.kubernetes.io/os": linux
         {{- with .Values.speaker.nodeSelector }}

--- a/helm-chart/templates/speaker.yaml
+++ b/helm-chart/templates/speaker.yaml
@@ -56,9 +56,9 @@ spec:
           readOnlyRootFilesystem: true
           capabilities:
             drop:
-            - all
+            - ALL
             add:
-            - net_raw
+            - NET_RAW
       nodeSelector:
         "beta.kubernetes.io/os": linux
         {{- with .Values.speaker.nodeSelector }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -23,6 +23,11 @@ rbac:
   # create specifies whether to install and use RBAC rules.
   create: true
 
+psp:
+  # create specifies whether to install and use Pod Security Policies.
+  # This only apples to L2 mode.
+  create: true
+
 prometheus:
   # scrape annotations specifies whether to add Prometheus metric
   # auto-collection annotations to pods. See

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -25,7 +25,6 @@ rbac:
 
 psp:
   # create specifies whether to install and use Pod Security Policies.
-  # This only apples to L2 mode.
   create: true
 
 prometheus:

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -20,7 +20,9 @@ spec:
   privileged: true
   allowPrivilegeEscalation: false
   allowedCapabilities:
+  - 'NET_ADMIN'
   - 'NET_RAW'
+  - 'SYS_ADMIN'
   volumes:
   - '*'
   fsGroup:
@@ -201,7 +203,9 @@ spec:
             drop:
             - ALL
             add:
+            - NET_ADMIN
             - NET_RAW
+            - SYS_ADMIN
       nodeSelector:
         "beta.kubernetes.io/os": linux
 

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -5,6 +5,33 @@ metadata:
   labels:
     app: metallb
 ---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  namespace: metallb-system
+  name: speaker
+  labels:
+    app: metallb
+spec:
+  hostNetwork: true
+  hostPorts:
+  - min: 7472
+    max: 7472
+  privileged: true
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - 'NET_RAW'
+  volumes:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+---
 
 apiVersion: v1
 kind: ServiceAccount
@@ -50,6 +77,10 @@ rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: ["speaker"]
+  verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -168,9 +199,9 @@ spec:
           readOnlyRootFilesystem: true
           capabilities:
             drop:
-            - all
+            - ALL
             add:
-            - net_raw
+            - NET_RAW
       nodeSelector:
         "beta.kubernetes.io/os": linux
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add PodSecurityPolicy to Helm chart and rendered manifest. For clusters with a PSP admissions controller, the default Capabilities will prevent the Speaker daemon set from running.

Capabilities were tested with eBFP tracing on Speaker, `NET_ADMIN` and `SYS_ADMIN` are required (on my `x86_64` CentOS 7 cluster anyway). In actual testing, the caps don't really matter because the process is running as root, they only need to be set so the policy can be selected properly. `RunAsUser` has been left as any until the image itself is able to use a non-root user. This should be tightened up when possible.

**Special notes for your reviewer**:
Also fixed a bug in the Makefile so `sed` on Mac works. Spacing between template blocks is still kinda weird and it's possible to export the PSP manifest independently, but I'm not sure how to keep the RBAC binding for it independent since it's an extension of the default. PSP has been enabled in the Makefile but I can disable this if changing the default isn't wanted. As far as I know, having a PSP without the controller will just ignore it though.


**Example of rendering just the PodSecurityPolicy template:**

````
$ cd helm-charts
$ helm template \
       --namespace metallb-system \
       --set psp.create=true \
       --execute templates/psp.yaml . > ../psp.yaml
````