### PR TITLE
Documentation; Fix for #376. Unit added for hold-time

### DIFF
--- a/manifests/example-config.yaml
+++ b/manifests/example-config.yaml
@@ -20,7 +20,7 @@ data:
       peer-port: 179
       # (optional) The proposed value of the BGP Hold Time timer. Refer to
       # BGP reference material to understand what setting this implies.
-      hold-time: 120
+      hold-time: 120s
       # (optional) The router ID to use when connecting to this peer. Defaults
       # to the node IP address. Generally only useful when you need to peer with
       # another BGP router running on the same machine as MetalLB.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add required unit for the `hold-time` Duration. Fixes parsing errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #376

**Special notes for your reviewer**:
