### PR TITLE
WIP Add end 2 end tests using kubeadm-dind-cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,86 @@ jobs:
       - run: make ci-prepare
       - run: make gen-image-targets TAG=${CIRCLE_BRANCH:-${CIRCLE_TAG}} REGISTRY=metallb
       - run: make -f Makefile.image-targets test-bgp-router
+  e2e-dind-test-1.13:
+    working_directory: /go/src/go.universe.tf/metallb
+    docker:
+      - image: ubuntu:16.04
+    environment:
+      DOCKER_VERSION: "17.03.0-ce"
+      DIND_K8S_VERSION: v1.13
+      CNI_PLUGIN: bridge
+      DIND_CRI: docker
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Set up the environment
+          command: |
+            apt-get -qq update
+            apt-get install -y curl ca-certificates git liblz4-tool rsync socat tzdata wget
+            curl -sSL -o "/tmp/docker-${DOCKER_VERSION}.tgz" "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz"
+            tar -xz -C /tmp -f "/tmp/docker-${DOCKER_VERSION}.tgz"
+            mv /tmp/docker/* /usr/bin
+            # create a dummy container which will hold a volume with config
+            docker create -v /etc/quagga --name configs alpine:3.4 /bin/true
+            docker cp $PWD/e2etest/kdc-dind/quagga/. configs:/etc/quagga
+            wget https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/build/portforward.sh
+            chmod +x portforward.sh
+            ./portforward.sh start
+      - run:
+          name: Bring up the test scenario
+          command: | 
+            wget https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.13.sh
+            export DIND_PORT_FORWARDER_WAIT=1
+            export DIND_PORT_FORWARDER="${PWD}/portforward.sh"
+            chmod +x dind-cluster-v1.13.sh
+            ./dind-cluster-v1.13.sh up
+            docker run --privileged --rm -d --volumes-from configs --net kubeadm-dind-net --ip 10.192.0.201 --name extBGP1 ewindisch/quagga
+            docker run --privileged --rm -d --volumes-from configs --net kubeadm-dind-net --ip 10.192.0.202 --name extBGP2 ewindisch/quagga
+      - run:
+          name: Update PATH and Define Environment Variable at Runtime
+          command: |
+            echo 'export PATH=$HOME/.kubeadm-dind-cluster:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Install and configure metallb
+          command: |
+            API_SERVER_PORT="$( "${PWD}/dind-cluster-v1.13.sh" apiserver-port )"
+            "${PWD}/portforward.sh" -wait $API_SERVER_PORT
+            kubectl "--server=:${API_SERVER_PORT}" apply -f $PWD/e2etest/kdc-dind/metallb/metallb.yaml
+            kubectl "--server=:${API_SERVER_PORT}" apply -f $PWD/e2etest/kdc-dind/metallb/config.yaml
+            kubectl "--server=:${API_SERVER_PORT}" get pods -n metallb-system -o wide
+            sleep 30
+            kubectl "--server=:${API_SERVER_PORT}" get pods -n metallb-system -o wide
+      - run:
+          name: Deploy a new service
+          command: |
+            API_SERVER_PORT="$( "${PWD}/dind-cluster-v1.13.sh" apiserver-port )"
+            "${PWD}/portforward.sh" -wait $API_SERVER_PORT
+            kubectl "--server=:${API_SERVER_PORT}" apply -f $PWD/e2etest/kdc-dind/metallb/k8s-svc.yaml
+            sleep 30
+            docker exec extBGP1 ip a
+            docker exec extBGP1 ip route
+            docker exec extBGP1 vtysh -c "show ip bgp summary"
+            docker exec extBGP1 vtysh -c "show ip bgp neigh"
+            docker exec extBGP2 ip a
+            docker exec extBGP2 ip route
+            docker exec extBGP2 vtysh -c "show ip bgp summary"
+            docker exec extBGP2 vtysh -c "show ip bgp neigh"
+      - run:
+          name: Shutdown and clean up the environment
+          command: |
+            docker stop extBGP1
+            docker stop extBGP2
+            ./dind-cluster-v1.13.sh down
+            ./dind-cluster-v1.13.sh clean
+
 workflows:
   version: 2
+  test-e2e-dind:
+    jobs:
+      - e2e-dind-test-1.13
   test-and-deploy:
     jobs:
       - test-1.11:

--- a/e2etest/kdc-dind/metallb/config.yaml
+++ b/e2etest/kdc-dind/metallb/config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    peers:
+    - my-asn: 64512
+      peer-asn: 64512
+      peer-address: 10.192.0.201
+    - my-asn: 64512
+      peer-asn: 64512
+      peer-address: 10.192.0.202
+    address-pools:
+    - name: my-ip-space
+      protocol: bgp
+      addresses:
+      - 10.51.51.0/24

--- a/e2etest/kdc-dind/metallb/k8s-svc.yaml
+++ b/e2etest/kdc-dind/metallb/k8s-svc.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1
+        ports:
+        - name: http
+          containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: nginx
+  type: LoadBalancer

--- a/e2etest/kdc-dind/metallb/metallb.yaml
+++ b/e2etest/kdc-dind/metallb/metallb.yaml
@@ -1,0 +1,232 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    app: metallb
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: metallb-system
+  name: controller
+  labels:
+    app: metallb
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: metallb-system
+  name: speaker
+  labels:
+    app: metallb
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metallb-system:controller
+  labels:
+    app: metallb
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["services/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metallb-system:speaker
+  labels:
+    app: metallb
+rules:
+- apiGroups: [""]
+  resources: ["services", "endpoints", "nodes"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: metallb-system
+  name: config-watcher
+  labels:
+    app: metallb
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+
+## Role bindings
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-system:controller
+  labels:
+    app: metallb
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-system:speaker
+  labels:
+    app: metallb
+subjects:
+- kind: ServiceAccount
+  name: speaker
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: metallb-system
+  name: config-watcher
+  labels:
+    app: metallb
+subjects:
+- kind: ServiceAccount
+  name: controller
+- kind: ServiceAccount
+  name: speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: config-watcher
+---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  namespace: metallb-system
+  name: speaker
+  labels:
+    app: metallb
+    component: speaker
+spec:
+  selector:
+    matchLabels:
+      app: metallb
+      component: speaker
+  template:
+    metadata:
+      labels:
+        app: metallb
+        component: speaker
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: speaker
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: speaker
+        image: metallb/speaker:master
+        imagePullPolicy: Always
+        args:
+        - --port=7472
+        - --config=config
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - all
+            add:
+            - net_raw
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
+
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  namespace: metallb-system
+  name: controller
+  labels:
+    app: metallb
+    component: controller
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+  template:
+    metadata:
+      labels:
+        app: metallb
+        component: controller
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+    spec:
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
+      containers:
+      - name: controller
+        image: metallb/controller:master
+        imagePullPolicy: Always
+        args:
+        - --port=7472
+        - --config=config
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+
+---
+
+

--- a/e2etest/kdc-dind/quagga/bgpd.conf
+++ b/e2etest/kdc-dind/quagga/bgpd.conf
@@ -1,0 +1,20 @@
+! -*- bgp -*-
+!
+! BGPd sample configuratin file
+!
+! $Id: bgpd.conf.sample,v 1.1 2002/12/13 20:15:29 paul Exp $
+!
+hostname bgpd
+password zebra
+!enable password please-set-at-here
+!
+!
+router bgp 64512
+ neighbor 10.192.0.3 remote-as 64512
+ neighbor 10.192.0.3 next-hop-self
+ neighbor 10.192.0.4 remote-as 64512
+ neighbor 10.192.0.4 next-hop-self
+
+!log file /var/log/quagga/bgpd.log
+!
+log stdout

--- a/e2etest/kdc-dind/quagga/zebra.conf
+++ b/e2etest/kdc-dind/quagga/zebra.conf
@@ -1,0 +1,16 @@
+! -*- zebra -*-
+!
+! zebra sample configuration file
+!
+! $Id: zebra.conf.sample,v 1.1 2002/12/13 20:15:30 paul Exp $
+!
+hostname Router
+password zebra
+enable password zebra
+!
+! Interface's description. 
+!
+!interface lo
+! description test of desc.
+!
+!log file /var/log/quagga/zebra.log


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:

This PR adds e2e tests using containers to deploy a multinode k8s cluster and 2 external BGP routers.
The current code executes the following steps:

- Deploys a k8s cluster with 1 master and 2 workers
- Deploys 2 external BGP routers in the same network that the k8s cluster
- Installs metalLB
- Configures BGP sessions between metalLB and the external BGP routers
- Deploys a nginx service in the k8s cluster and exposes it using a LoadBalancer
- Checks that the IP assigned to the LoadBalancer has been learned by the external BGP routers


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #192 



**Special notes for your reviewer**:

I guess we should define first:

- [ ] Test matrix against k8s, i.e. what k8s versions do we want to include
- [ ] testing framework: gingko, bash, bats, ...
- [ ] test plan, scenarios, periodic jobs, ...
