### PR TITLE
incorrect configuration instructions in README.md

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -111,7 +111,7 @@ config:
   address-pools:
   - name: default
     protocol: bgp
-    cidr:
+    addresses:
     - 198.51.100.0/24
 
 $ helm install --name metallb -f values.yaml stable/metallb


### PR DESCRIPTION
You had `cidr` (the old configuration key) instead of `addresses`, (the new configuration key) in the README.md file.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our [contributing guide](https://metallb.universe.tf/hacking)
2. For non-trivial pull requests, please [file an issue]() first to
 discuss your proposed change and make sure it fits with MetalLB's
 overall goals.
-->

**What this PR does / why we need it**:



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #



**Special notes for your reviewer**:
