### PR TITLE
Add service to the announced ones

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -189,6 +189,7 @@ func (a *Announce) SetBalancer(name string, ip net.IP) {
 	if _, ok := a.ips[name]; ok {
 		return
 	}
+	a.ips[name] = ip
 
 	a.ipRefcnt[ip.String()]++
 	if a.ipRefcnt[ip.String()] > 1 {
@@ -203,7 +204,6 @@ func (a *Announce) SetBalancer(name string, ip net.IP) {
 		}
 	}
 
-	a.ips[name] = ip
 	go a.spam(name)
 
 }

--- a/internal/layer2/announcer_test.go
+++ b/internal/layer2/announcer_test.go
@@ -1,0 +1,35 @@
+package layer2
+
+import (
+	"net"
+	"testing"
+)
+
+func Test_SetBalancer_AddsToAnnouncedServices(t *testing.T) {
+	announce := &Announce{
+		ips:      map[string]net.IP{},
+		ipRefcnt: map[string]int{},
+	}
+
+	services := []struct {
+		name string
+		ip   net.IP
+	}{
+		{
+			name: "foo",
+			ip:   net.IPv4(192, 168, 1, 20),
+		},
+		{
+			name: "bar",
+			ip:   net.IPv4(192, 168, 1, 20),
+		},
+	}
+
+	for _, service := range services {
+		announce.SetBalancer(service.name, service.ip)
+
+		if !announce.AnnounceName(service.name) {
+			t.Fatalf("service %v is not anounced", service.name)
+		}
+	}
+}


### PR DESCRIPTION
Multiple services with the same IP address should be added to the list of the announced services no matter how many times the IP address is used.

**What this PR does / why we need it**:
This PR is fixing the issue when layer 2 ARP announcer function SetBalancer is called multiple times for several services sharing the same IP address. After adding the first service the following calls of SetBalancer with the same IP address increasing the IP address usage counter but do not add services to the list of the announced ones. This prevents DeleteBalancer from releasing the IP address when the services are not announced anymore. 

Fixes #402 
